### PR TITLE
docs: set import path for requirements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,12 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
-import craft_store
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path("..").absolute()))
+
+import craft_store  # noqa: E402
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Path needs to be set before importing craft_store which is where the
version is stored.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----