### PR TITLE
endpoints: new component to abstract endpoints for different stores (CRAFT-454)

### DIFF
--- a/craft_store/endpoints.py
+++ b/craft_store/endpoints.py
@@ -1,0 +1,75 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Endpoint definitions for different services."""
+
+import dataclasses
+from typing import Any, Dict, Final, Sequence
+
+
+@dataclasses.dataclass(repr=True)
+class Endpoints:
+    """Endpoints used to make requests to a store.
+
+    :param whoami: path to the whoami API.
+    :param tokens: path to the tokens API.
+    :param tokens_exchange: path to the tokens_exchange API.
+    """
+
+    whoami: str
+    tokens: str
+    tokens_exchange: str
+
+    @staticmethod
+    def _get_token_request(
+        *, permissions: Sequence[str], description: str, ttl: str
+    ) -> Dict[str, Any]:
+        return {
+            "permissions": permissions,
+            "description": description,
+            "ttl": ttl,
+        }
+
+
+@dataclasses.dataclass(repr=True)
+class _SnapStoreEndpoints(Endpoints):
+    """Snap Store endpoints used to make requests to a store."""
+
+    @staticmethod
+    def _get_token_request(
+        *, permissions: Sequence[str], description: str, ttl: str
+    ) -> Dict[str, Any]:
+        return {
+            "attenuations": permissions,
+            "description": description,
+            "expiry": ttl,
+        }
+
+
+CHARMHUB: Final = Endpoints(
+    whoami="/v1/whoami",
+    tokens="/v1/tokens",
+    tokens_exchange="/v1/tokens/exchange",
+)
+"""Charmhub set of supported endpoints."""
+
+
+SNAP_STORE: Final = _SnapStoreEndpoints(
+    whoami="/api/v2/tokens/whoami",
+    tokens="/api/v2/tokens",
+    tokens_exchange="/api/v2/tokens/exchange",
+)
+"""Snap Store set of supported endpoints."""

--- a/craft_store/endpoints.py
+++ b/craft_store/endpoints.py
@@ -34,9 +34,17 @@ class Endpoints:
     tokens_exchange: str
 
     @staticmethod
-    def _get_token_request(
+    def get_token_request(
         *, permissions: Sequence[str], description: str, ttl: str
     ) -> Dict[str, Any]:
+        """Return a properly formatted request for a token request.
+
+        Permissions can be selected from :data:`craft_store.attenuations`
+
+        :param permissions: a list of permissions to use.
+        :param description: description that identifies the client.
+        :param ttl: time to live for the requested token.
+        """
         return {
             "permissions": permissions,
             "description": description,
@@ -49,7 +57,7 @@ class _SnapStoreEndpoints(Endpoints):
     """Snap Store endpoints used to make requests to a store."""
 
     @staticmethod
-    def _get_token_request(
+    def get_token_request(
         *, permissions: Sequence[str], description: str, ttl: str
     ) -> Dict[str, Any]:
         return {

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -1,0 +1,52 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from craft_store import endpoints
+
+
+def test_charmhub():
+    charmhub = endpoints.CHARMHUB
+
+    assert charmhub.tokens == "/v1/tokens"
+    assert charmhub.tokens_exchange == "/v1/tokens/exchange"
+    assert charmhub.whoami == "/v1/whoami"
+    assert charmhub._get_token_request(  # pylint: disable=W0212
+        permissions=["permission-foo", "permission-bar"],
+        description="client description",
+        ttl="1000",
+    ) == {
+        "permissions": ["permission-foo", "permission-bar"],
+        "description": "client description",
+        "ttl": "1000",
+    }
+
+
+def test_snap_store():
+    snap_store = endpoints.SNAP_STORE
+
+    assert snap_store.tokens == "/api/v2/tokens"
+    assert snap_store.tokens_exchange == "/api/v2/tokens/exchange"
+    assert snap_store.whoami == "/api/v2/tokens/whoami"
+    assert snap_store._get_token_request(  # pylint: disable=W0212
+        permissions=["permission-foo", "permission-bar"],
+        description="client description",
+        ttl="1000",
+    ) == {
+        "attenuations": ["permission-foo", "permission-bar"],
+        "description": "client description",
+        "expiry": "1000",
+    }

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -24,7 +24,7 @@ def test_charmhub():
     assert charmhub.tokens == "/v1/tokens"
     assert charmhub.tokens_exchange == "/v1/tokens/exchange"
     assert charmhub.whoami == "/v1/whoami"
-    assert charmhub._get_token_request(  # pylint: disable=W0212
+    assert charmhub.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",
         ttl="1000",
@@ -41,7 +41,7 @@ def test_snap_store():
     assert snap_store.tokens == "/api/v2/tokens"
     assert snap_store.tokens_exchange == "/api/v2/tokens/exchange"
     assert snap_store.whoami == "/api/v2/tokens/whoami"
-    assert snap_store._get_token_request(  # pylint: disable=W0212
+    assert snap_store.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",
         ttl="1000",


### PR DESCRIPTION
Charmhub and Snap Store use different paths for similar API calls.
This is an abstraction for that.

Additionally provides an internal method to convert the required
payload for the .tokens endpoint.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----