### PR TITLE
endpoints: support packages and channels (CRAFT-637)

### DIFF
--- a/craft_store/endpoints.py
+++ b/craft_store/endpoints.py
@@ -48,7 +48,7 @@ class Endpoints:
         ]
         if unknown_packages:
             unknown_package_types = [p.package_type for p in unknown_packages]
-            raise RuntimeError(
+            raise ValueError(
                 f"Package types {unknown_package_types} not in {self.valid_package_types}"
             )
 

--- a/craft_store/endpoints.py
+++ b/craft_store/endpoints.py
@@ -17,7 +17,15 @@
 """Endpoint definitions for different services."""
 
 import dataclasses
-from typing import Any, Dict, Final, Sequence
+from typing import Any, Dict, Final, Optional, Sequence
+
+
+@dataclasses.dataclass(frozen=True)
+class Package:
+    """Representation of a package name and type."""
+
+    package_name: str
+    package_type: str
 
 
 @dataclasses.dataclass(repr=True)
@@ -32,10 +40,26 @@ class Endpoints:
     whoami: str
     tokens: str
     tokens_exchange: str
+    valid_package_types: Sequence[str]
 
-    @staticmethod
+    def _validate_packages(self, packages: Sequence[Package]) -> None:
+        unknown_packages = [
+            p for p in packages if p.package_type not in self.valid_package_types
+        ]
+        if unknown_packages:
+            unknown_package_types = [p.package_type for p in unknown_packages]
+            raise RuntimeError(
+                f"Package types {unknown_package_types} not in {self.valid_package_types}"
+            )
+
     def get_token_request(
-        *, permissions: Sequence[str], description: str, ttl: int
+        self,
+        *,
+        permissions: Sequence[str],
+        description: str,
+        ttl: int,
+        channels: Optional[Sequence[str]] = None,
+        packages: Optional[Sequence[Package]] = None,
     ) -> Dict[str, Any]:
         """Return a properly formatted request for a token request.
 
@@ -44,33 +68,66 @@ class Endpoints:
         :param permissions: a list of permissions to use.
         :param description: description that identifies the client.
         :param ttl: time to live for the requested token.
+        :param packages: a sequence of :attr:`Package` to limit the requested token to.
+        :param channels: a sequence of channels to limit the requested token to.
         """
-        return {
+        token_request = {
             "permissions": permissions,
             "description": description,
             "ttl": ttl,
         }
+
+        if packages:
+            self._validate_packages(packages)
+            token_request["packages"] = [
+                {"type": p.package_type, "name": p.package_name} for p in packages
+            ]
+
+        if channels:
+            token_request["channels"] = channels
+
+        return token_request
 
 
 @dataclasses.dataclass(repr=True)
 class _SnapStoreEndpoints(Endpoints):
     """Snap Store endpoints used to make requests to a store."""
 
-    @staticmethod
     def get_token_request(
-        *, permissions: Sequence[str], description: str, ttl: int
+        self,
+        *,
+        permissions: Sequence[str],
+        description: str,
+        ttl: int,
+        channels: Optional[Sequence[str]] = None,
+        packages: Optional[Sequence[Package]] = None,
     ) -> Dict[str, Any]:
-        return {
+        token_request: Dict[str, Any] = {
             "permissions": permissions,
             "description": description,
             "expires": str(ttl),
         }
+
+        if packages:
+            self._validate_packages(packages)
+            token_request["packages"] = [
+                # Originally, snaps were supposed to be versioned by series,
+                # this all changed with the introduction of bases.
+                {"series": "16", "name": p.package_name}
+                for p in packages
+            ]
+
+        if channels:
+            token_request["channels"] = channels
+
+        return token_request
 
 
 CHARMHUB: Final = Endpoints(
     whoami="/v1/whoami",
     tokens="/v1/tokens",
     tokens_exchange="/v1/tokens/exchange",
+    valid_package_types=["charm", "bundle"],
 )
 """Charmhub set of supported endpoints."""
 
@@ -79,5 +136,6 @@ SNAP_STORE: Final = _SnapStoreEndpoints(
     whoami="/api/v2/tokens/whoami",
     tokens="/api/v2/tokens",
     tokens_exchange="/api/v2/tokens/exchange",
+    valid_package_types=["snap"],
 )
 """Snap Store set of supported endpoints."""

--- a/craft_store/store_client.py
+++ b/craft_store/store_client.py
@@ -18,7 +18,7 @@
 
 import base64
 import json
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Optional, Sequence
 from urllib.parse import urlparse
 
 import requests
@@ -75,7 +75,7 @@ class StoreClient(HTTPClient):
         self,
         *,
         base_url: str,
-        endpoints: endpoints.Endpoints,
+        endpoints: endpoints.Endpoints,  # pylint: disable=W0621
         application_name: str,
         user_agent: str,
     ) -> None:
@@ -134,6 +134,8 @@ class StoreClient(HTTPClient):
         permissions: Sequence[str],
         description: str,
         ttl: int,
+        packages: Optional[Sequence[endpoints.Package]] = None,
+        channels: Optional[Sequence[str]] = None,
     ) -> None:
         """Obtain credentials to perform authenticated requests.
 
@@ -157,10 +159,15 @@ class StoreClient(HTTPClient):
         :param description: Client description to refer to from the Store.
         :param ttl: time to live for the credential, in other words, how
                     long until it expires, expressed in seconds.
-
+        :param packages: Sequence of packages to limit the credentials to.
+        :param channels: Sequence of channel names to limit the credentials to.
         """
         token_request = self._endpoints.get_token_request(
-            permissions=permissions, description=description, ttl=ttl
+            permissions=permissions,
+            description=description,
+            ttl=ttl,
+            packages=packages,
+            channels=channels,
         )
 
         macaroon = self._get_macaroon(token_request)

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 
 from craft_store import endpoints
 
@@ -35,6 +36,62 @@ def test_charmhub():
     }
 
 
+def test_charmhub_channels():
+    charmhub = endpoints.CHARMHUB
+
+    assert charmhub.get_token_request(
+        permissions=["permission-foo", "permission-bar"],
+        description="client description",
+        ttl=1000,
+        channels=["stable", "track/edge"],
+    ) == {
+        "permissions": ["permission-foo", "permission-bar"],
+        "description": "client description",
+        "ttl": 1000,
+        "channels": ["stable", "track/edge"],
+    }
+
+
+def test_charmhub_packages():
+    charmhub = endpoints.CHARMHUB
+
+    assert charmhub.get_token_request(
+        permissions=["permission-foo", "permission-bar"],
+        description="client description",
+        ttl=1000,
+        packages=[
+            endpoints.Package("charm1", "charm"),
+            endpoints.Package("bundle1", "bundle"),
+        ],
+    ) == {
+        "permissions": ["permission-foo", "permission-bar"],
+        "description": "client description",
+        "ttl": 1000,
+        "packages": [
+            {"type": "charm", "name": "charm1"},
+            {"type": "bundle", "name": "bundle1"},
+        ],
+    }
+
+
+def test_charmhub_invalid_packages():
+    charmhub = endpoints.CHARMHUB
+
+    with pytest.raises(RuntimeError) as raised:
+        charmhub.get_token_request(
+            permissions=["permission-foo", "permission-bar"],
+            description="client description",
+            ttl=1000,
+            packages=[
+                endpoints.Package("charm1", "snap"),
+                endpoints.Package("bundle1", "rock"),
+            ],
+        )
+    assert (
+        str(raised.value) == "Package types ['snap', 'rock'] not in ['charm', 'bundle']"
+    )
+
+
 def test_snap_store():
     snap_store = endpoints.SNAP_STORE
 
@@ -50,3 +107,57 @@ def test_snap_store():
         "description": "client description",
         "expires": "1000",
     }
+
+
+def test_snap_store_channels():
+    snap_store = endpoints.SNAP_STORE
+
+    assert snap_store.get_token_request(
+        permissions=["permission-foo", "permission-bar"],
+        description="client description",
+        ttl=1000,
+        channels=["stable", "track/edge"],
+    ) == {
+        "permissions": ["permission-foo", "permission-bar"],
+        "description": "client description",
+        "expires": "1000",
+        "channels": ["stable", "track/edge"],
+    }
+
+
+def test_snap_store_packages():
+    snap_store = endpoints.SNAP_STORE
+
+    assert snap_store.get_token_request(
+        permissions=["permission-foo", "permission-bar"],
+        description="client description",
+        ttl=1000,
+        packages=[
+            endpoints.Package("snap1", "snap"),
+            endpoints.Package("snap2", "snap"),
+        ],
+    ) == {
+        "permissions": ["permission-foo", "permission-bar"],
+        "description": "client description",
+        "expires": "1000",
+        "packages": [
+            {"series": "16", "name": "snap1"},
+            {"series": "16", "name": "snap2"},
+        ],
+    }
+
+
+def test_snap_store_invalid_packages():
+    snap_store = endpoints.SNAP_STORE
+
+    with pytest.raises(RuntimeError) as raised:
+        snap_store.get_token_request(
+            permissions=["permission-foo", "permission-bar"],
+            description="client description",
+            ttl=1000,
+            packages=[
+                endpoints.Package("snap1", "charm"),
+                endpoints.Package("snap2", "rock"),
+            ],
+        )
+    assert str(raised.value) == "Package types ['charm', 'rock'] not in ['snap']"

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -77,7 +77,7 @@ def test_charmhub_packages():
 def test_charmhub_invalid_packages():
     charmhub = endpoints.CHARMHUB
 
-    with pytest.raises(RuntimeError) as raised:
+    with pytest.raises(ValueError) as raised:
         charmhub.get_token_request(
             permissions=["permission-foo", "permission-bar"],
             description="client description",
@@ -150,7 +150,7 @@ def test_snap_store_packages():
 def test_snap_store_invalid_packages():
     snap_store = endpoints.SNAP_STORE
 
-    with pytest.raises(RuntimeError) as raised:
+    with pytest.raises(ValueError) as raised:
         snap_store.get_token_request(
             permissions=["permission-foo", "permission-bar"],
             description="client description",


### PR DESCRIPTION
Required in order to support attenuated macaroons that work with a set
of specific packages or channels.

A higher level Package class is introduced to simplify the
presentation of StoreClient's login method.

A RuntimeError is raised to ease development when improper package
types are used for each endpoint (Snap Store and Charmhub).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----