### PR TITLE
auth: support credentials from the environment (CRAFT-638)

### DIFF
--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -46,10 +46,7 @@ class MemoryKeyring(keyring.backend.KeyringBackend):
 
     def get_password(self, service: str, username: str) -> Optional[str]:
         """Get the service password for username from memory."""
-        try:
-            return self._credentials[service, username]
-        except KeyError:
-            return None
+        return self._credentials.get((service, username))
 
     def delete_password(self, service: str, username: str) -> None:
         """Delete the service password for username from memory."""

--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -89,7 +89,7 @@ class Auth:
 
         environment_auth_value = None
         if environment_auth:
-            environment_auth_value = os.getenv(environment_auth, None)
+            environment_auth_value = os.getenv(environment_auth)
 
         if environment_auth_value:
             keyring.set_keyring(MemoryKeyring())

--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -93,7 +93,17 @@ class Auth:
 
         if environment_auth_value:
             keyring.set_keyring(MemoryKeyring())
-            self.set_credentials(environment_auth_value)
+            self.set_credentials(self.decode_credentials(environment_auth_value))
+
+    @staticmethod
+    def decode_credentials(encoded_credentials: str) -> str:
+        """Decode base64 encoded credentials."""
+        return base64.b64decode(encoded_credentials).decode()
+
+    @staticmethod
+    def encode_credentials(credentials: str) -> str:
+        """Encode credentials to base64."""
+        return base64.b64encode(credentials.encode()).decode()
 
     def set_credentials(self, credentials: str) -> None:
         """Store credentials in the keyring.
@@ -105,10 +115,8 @@ class Auth:
             self.application_name,
             self.host,
         )
-        encoded_credentials = base64.b64encode(credentials.encode())
-        keyring.set_password(
-            self.application_name, self.host, encoded_credentials.decode()
-        )
+        encoded_credentials = self.encode_credentials(credentials)
+        keyring.set_password(self.application_name, self.host, encoded_credentials)
 
     def get_credentials(self) -> str:
         """Retrieve credentials from the keyring."""
@@ -134,7 +142,7 @@ class Auth:
                 "Credentials not found in the keyring %r", keyring.get_keyring().name
             )
             raise errors.NotLoggedIn()
-        credentials = base64.b64decode(encoded_credentials_string).decode()
+        credentials = self.decode_credentials(encoded_credentials_string)
         return credentials
 
     def del_credentials(self) -> None:

--- a/craft_store/store_client.py
+++ b/craft_store/store_client.py
@@ -180,7 +180,7 @@ class StoreClient(HTTPClient):
         # Save the authorization token.
         self._auth.set_credentials(store_authorized_macaroon)
 
-        return store_authorized_macaroon
+        return self._auth.encode_credentials(store_authorized_macaroon)
 
     def request(
         self,

--- a/craft_store/store_client.py
+++ b/craft_store/store_client.py
@@ -78,6 +78,7 @@ class StoreClient(HTTPClient):
         endpoints: endpoints.Endpoints,  # pylint: disable=W0621
         application_name: str,
         user_agent: str,
+        environment_auth: Optional[str] = None,
     ) -> None:
         """Initialize the Store Client.
 
@@ -85,6 +86,7 @@ class StoreClient(HTTPClient):
         :param endpoints: :data:`.endpoints.CHARMHUB` or :data:`.endpoints.SNAP_STORE`.
         :param application_name: the name application using this class, used for the keyring.
         :param user_agent: User-Agent header to use for HTTP(s) requests.
+        :param environment_credentials: environment variable to use for credentials.
         """
         super().__init__(user_agent=user_agent)
 
@@ -94,7 +96,8 @@ class StoreClient(HTTPClient):
         self._base_url = base_url
         self._store_host = urlparse(base_url).netloc
         self._endpoints = endpoints
-        self._auth = Auth(application_name, base_url)
+
+        self._auth = Auth(application_name, base_url, environment_auth=environment_auth)
 
     def _get_macaroon(self, token_request: Dict[str, Any]) -> str:
         token_response = super().request(
@@ -136,7 +139,7 @@ class StoreClient(HTTPClient):
         ttl: int,
         packages: Optional[Sequence[endpoints.Package]] = None,
         channels: Optional[Sequence[str]] = None,
-    ) -> None:
+    ) -> str:
         """Obtain credentials to perform authenticated requests.
 
         Credentials are stored on the systems keyring, handled by
@@ -176,6 +179,8 @@ class StoreClient(HTTPClient):
 
         # Save the authorization token.
         self._auth.set_credentials(store_authorized_macaroon)
+
+        return store_authorized_macaroon
 
     def request(
         self,

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -52,7 +52,7 @@ def test_auth():
 
 
 def test_auth_from_environment(monkeypatch):
-    monkeypatch.setenv("CREDENTIALS", "secret-keys")
+    monkeypatch.setenv("CREDENTIALS", "c2VjcmV0LWtleXM=")
 
     auth = Auth("fakecraft", "fakestore.com", "CREDENTIALS")
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -189,13 +189,13 @@ def test_del_credentials_gets_no_credential(caplog, keyring_get_mock):
 
 
 def test_environment_set(monkeypatch, keyring_set_keyring_mock, keyring_set_mock):
-    monkeypatch.setenv("FAKE_ENV", "keys-to-the-kingdom")
+    monkeypatch.setenv("FAKE_ENV", "c2VjcmV0LWtleXM=")
 
     Auth("fakeclient", "fakestore.com", environment_auth="FAKE_ENV")
 
     assert keyring_set_keyring_mock.mock_calls == [ANY]
     assert keyring_set_mock.mock_calls == [
-        call("fakeclient", "fakestore.com", "a2V5cy10by10aGUta2luZ2RvbQ==")
+        call("fakeclient", "fakestore.com", "c2VjcmV0LWtleXM=")
     ]
 
 

--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -108,14 +108,20 @@ def auth_mock(real_macaroon):
     patched_auth.stop()
 
 
+@pytest.mark.parametrize("environment_auth", (None, "APPLICATION_CREDENTIALS"))
 def test_store_client_login(
-    http_client_request_mock, real_macaroon, bakery_discharge_mock, auth_mock
+    http_client_request_mock,
+    real_macaroon,
+    bakery_discharge_mock,
+    auth_mock,
+    environment_auth,
 ):
     store_client = StoreClient(
         base_url="https://fake-server.com",
         endpoints=endpoints.CHARMHUB,
         application_name="fakecraft",
         user_agent="FakeCraft Unix X11",
+        environment_auth=environment_auth,
     )
 
     store_client.login(
@@ -145,7 +151,7 @@ def test_store_client_login(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com"),
+        call("fakecraft", "https://fake-server.com", environment_auth=environment_auth),
         call().set_credentials(real_macaroon),
     ]
 
@@ -205,7 +211,7 @@ def test_store_client_login_with_packages_and_channels(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com"),
+        call("fakecraft", "https://fake-server.com", environment_auth=None),
         call().set_credentials(real_macaroon),
     ]
 
@@ -221,7 +227,7 @@ def test_store_client_logout(auth_mock):
     store_client.logout()
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com"),
+        call("fakecraft", "https://fake-server.com", environment_auth=None),
         call().del_credentials(),
     ]
 
@@ -247,7 +253,7 @@ def test_store_client_request(http_client_request_mock, real_macaroon, auth_mock
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com"),
+        call("fakecraft", "https://fake-server.com", environment_auth=None),
         call().get_credentials(),
     ]
 
@@ -277,7 +283,7 @@ def test_store_client_whoami(http_client_request_mock, real_macaroon, auth_mock)
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com"),
+        call("fakecraft", "https://fake-server.com", environment_auth=None),
         call().get_credentials(),
     ]
 

--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -104,6 +104,7 @@ def auth_mock(real_macaroon):
     patched_auth = patch("craft_store.store_client.Auth", autospec=True)
     mocked_auth = patched_auth.start()
     mocked_auth.return_value.get_credentials.return_value = real_macaroon
+    mocked_auth.return_value.encode_credentials.return_value = "c2VjcmV0LWtleXM="
     yield mocked_auth
     patched_auth.stop()
 
@@ -124,10 +125,11 @@ def test_store_client_login(
         environment_auth=environment_auth,
     )
 
-    store_client.login(
+    credentials = store_client.login(
         permissions=["perm-1", "perm-2"], description="fakecraft@foo", ttl=60
     )
 
+    assert credentials == "c2VjcmV0LWtleXM="
     assert http_client_request_mock.mock_calls == [
         call(
             store_client,
@@ -153,6 +155,7 @@ def test_store_client_login(
     assert auth_mock.mock_calls == [
         call("fakecraft", "https://fake-server.com", environment_auth=environment_auth),
         call().set_credentials(real_macaroon),
+        call().encode_credentials(real_macaroon),
     ]
 
 
@@ -166,7 +169,7 @@ def test_store_client_login_with_packages_and_channels(
         user_agent="FakeCraft Unix X11",
     )
 
-    store_client.login(
+    credentials = store_client.login(
         permissions=["perm-1", "perm-2"],
         description="fakecraft@foo",
         ttl=60,
@@ -177,6 +180,7 @@ def test_store_client_login_with_packages_and_channels(
         ],
     )
 
+    assert credentials == "c2VjcmV0LWtleXM="
     assert http_client_request_mock.mock_calls == [
         call(
             store_client,
@@ -213,6 +217,7 @@ def test_store_client_login_with_packages_and_channels(
     assert auth_mock.mock_calls == [
         call("fakecraft", "https://fake-server.com", environment_auth=None),
         call().set_credentials(real_macaroon),
+        call().encode_credentials(real_macaroon),
     ]
 
 


### PR DESCRIPTION
In order to allow a MemoryKeyring to be used together with environment
variables in an ephemeral workflow such as CI/CD.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----