### PR TITLE
readthedocs: remove legacy python.version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,6 @@ formats:
   - pdf
 
 python:
-  version: "3.8"
   install:
     - method: pip
       requirements: docs/requirements.txt


### PR DESCRIPTION
It is incompatible with the new build declaration.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----