### PR TITLE
readthedocs: type in configuration for requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,6 @@ formats:
 
 python:
   install:
+    - requirements: docs/requirements.txt
     - method: pip
-      requirements: docs/requirements.txt
       path: .


### PR DESCRIPTION
"requirements" needs to be its own list item.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----