### PR TITLE
store client: split common StoreClient functionality to a base class (CRAFT-690)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -150,7 +150,8 @@ disable=print-statement,
         comprehension-escape,
         line-too-long,
         fixme,
-        fixme-info
+        fixme-info,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-mypy:
 
 .PHONY: test-pydocstyle
 test-pydocstyle:
-	pydocstyle craft_store
+	pydocstyle craft_store --ignore-decorator=overrides
 
 .PHONY: test-pylint
 test-pylint:

--- a/craft_store/__init__.py
+++ b/craft_store/__init__.py
@@ -19,6 +19,16 @@
 __version__ = "1.1.0"
 
 
-from . import errors  # noqa: F401
-from .http_client import HTTPClient  # noqa: F401
-from .store_client import StoreClient  # noqa: F401
+from . import errors
+from .auth import Auth
+from .base_client import BaseClient
+from .http_client import HTTPClient
+from .store_client import StoreClient
+
+__all__ = [
+    "errors",
+    "Auth",
+    "BaseClient",
+    "HTTPClient",
+    "StoreClient",
+]

--- a/craft_store/base_client.py
+++ b/craft_store/base_client.py
@@ -1,0 +1,170 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Craft Store BaseClient."""
+
+from abc import ABCMeta, abstractmethod
+from typing import Any, Dict, Optional, Sequence
+from urllib.parse import urlparse
+
+import requests
+
+from . import endpoints
+from .auth import Auth
+from .http_client import HTTPClient
+
+
+class BaseClient(metaclass=ABCMeta):
+    """Encapsulates API calls for the Snap Store or Charmhub."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        endpoints: endpoints.Endpoints,  # pylint: disable=W0621
+        application_name: str,
+        user_agent: str,
+        environment_auth: Optional[str] = None,
+    ) -> None:
+        """Initialize the Store Client.
+
+        :param base_url: the base url of the API endpoint.
+        :param endpoints: :data:`.endpoints.CHARMHUB` or :data:`.endpoints.SNAP_STORE`.
+        :param application_name: the name application using this class, used for the keyring.
+        :param user_agent: User-Agent header to use for HTTP(s) requests.
+        :param environment_auth: environment variable to use for credentials.
+        """
+        self.http_client = HTTPClient(user_agent=user_agent)
+
+        self._base_url = base_url
+        self._store_host = urlparse(base_url).netloc
+        self._endpoints = endpoints
+
+        self._auth = Auth(application_name, base_url, environment_auth=environment_auth)
+
+    @abstractmethod
+    def _get_discharged_macaroon(self, root_macaroon: str, **kwargs) -> str:
+        """Return a discharged macaroon ready to use in an Authorization header."""
+
+    @abstractmethod
+    def _get_authorization_header(self) -> str:
+        """Return the authorization header content to use."""
+
+    def _get_macaroon(self, token_request: Dict[str, Any]) -> str:
+        token_response = self.http_client.request(
+            "POST",
+            self._base_url + self._endpoints.tokens,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            json=token_request,
+        )
+
+        return token_response.json()["macaroon"]
+
+    def login(
+        self,
+        *,
+        permissions: Sequence[str],
+        description: str,
+        ttl: int,
+        packages: Optional[Sequence[endpoints.Package]] = None,
+        channels: Optional[Sequence[str]] = None,
+        **kwargs,
+    ) -> str:
+        """Obtain credentials to perform authenticated requests.
+
+        Credentials are stored on the systems keyring, handled by
+        :data:`craft_store.auth.Auth`.
+
+        The list of permissions to select from can be referred to on
+        :data:`craft_store.attenuations`.
+
+        The login process requires 3 steps:
+
+        - request an initial macaroon on :attr:`.endpoints.Endpoints.tokens`.
+        - discharge that macaroon using Candid
+        - send the discharge macaroon to :attr:`.endpoints.Endpoints.tokens_exchange`
+          to obtain final authorization of the macaroon
+
+        This last macaroon is stored into the systems keyring to
+        perform authenticated requests.
+
+        :param permissions: Set of permissions to grant the login.
+        :param description: Client description to refer to from the Store.
+        :param ttl: time to live for the credential, in other words, how
+                    long until it expires, expressed in seconds.
+        :param packages: Sequence of packages to limit the credentials to.
+        :param channels: Sequence of channel names to limit the credentials to.
+        """
+        token_request = self._endpoints.get_token_request(
+            permissions=permissions,
+            description=description,
+            ttl=ttl,
+            packages=packages,
+            channels=channels,
+        )
+
+        macaroon = self._get_macaroon(token_request)
+        store_authorized_macaroon = self._get_discharged_macaroon(macaroon, **kwargs)
+
+        # Save the authorization token.
+        self._auth.set_credentials(store_authorized_macaroon)
+
+        return self._auth.encode_credentials(store_authorized_macaroon)
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        params: Dict[str, str] = None,
+        headers: Dict[str, str] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """Perform an authenticated request if auth_headers are True.
+
+        :param method: HTTP method used for the request.
+        :param url: URL to request with method.
+        :param params: Query parameters to be sent along with the request.
+        :param headers: Headers to be sent along with the request.
+
+        :raises errors.StoreServerError: for error responses.
+        :raises errors.NetworkError: for lower level network issues.
+        :raises errors.NotLoggedIn: if not logged in.
+
+        :return: Response from the request.
+        """
+        if headers is None:
+            headers = {}
+
+        headers["Authorization"] = self._get_authorization_header()
+
+        return self.http_client.request(
+            method,
+            url,
+            params=params,
+            headers=headers,
+            **kwargs,
+        )
+
+    def whoami(self) -> Dict[str, Any]:
+        """Return whoami json data queyring :attr:`.endpoints.Endpoints.whoami`."""
+        return self.request("GET", self._base_url + self._endpoints.whoami).json()
+
+    def logout(self) -> None:
+        """Clear credentials.
+
+        :raises errors.NotLoggedIn: if not logged in.
+        """
+        self._auth.del_credentials()

--- a/craft_store/store_client.py
+++ b/craft_store/store_client.py
@@ -18,15 +18,14 @@
 
 import base64
 import json
-from typing import Any, Dict, Optional, Sequence
-from urllib.parse import urlparse
+from typing import Optional
 
-import requests
 from macaroonbakery import bakery, httpbakery
+from overrides import overrides
 from pymacaroons.serializers import json_serializer
 
 from . import endpoints, errors
-from .auth import Auth
+from .base_client import BaseClient
 from .http_client import HTTPClient
 
 
@@ -68,9 +67,10 @@ class WebBrowserWaitingInteractor(httpbakery.WebBrowserInteractor):
         )
 
 
-class StoreClient(HTTPClient):
+class StoreClient(BaseClient):
     """Encapsulates API calls for the Snap Store or Charmhub."""
 
+    @overrides
     def __init__(
         self,
         *,
@@ -80,33 +80,21 @@ class StoreClient(HTTPClient):
         user_agent: str,
         environment_auth: Optional[str] = None,
     ) -> None:
-        """Initialize the Store Client.
-
-        :param base_url: the base url of the API endpoint.
-        :param endpoints: :data:`.endpoints.CHARMHUB` or :data:`.endpoints.SNAP_STORE`.
-        :param application_name: the name application using this class, used for the keyring.
-        :param user_agent: User-Agent header to use for HTTP(s) requests.
-        :param environment_auth: environment variable to use for credentials.
-        """
-        super().__init__(user_agent=user_agent)
+        super().__init__(
+            base_url=base_url,
+            endpoints=endpoints,
+            application_name=application_name,
+            user_agent=user_agent,
+            environment_auth=environment_auth,
+        )
 
         self._bakery_client = httpbakery.Client(
             interaction_methods=[WebBrowserWaitingInteractor(user_agent=user_agent)]
         )
-        self._base_url = base_url
-        self._store_host = urlparse(base_url).netloc
-        self._endpoints = endpoints
 
-        self._auth = Auth(application_name, base_url, environment_auth=environment_auth)
-
-    def _get_macaroon(self, token_request: Dict[str, Any]) -> str:
-        token_response = super().request(
-            "POST",
-            self._base_url + self._endpoints.tokens,
-            json=token_request,
-        )
-
-        return token_response.json()["macaroon"]
+    def _get_authorization_header(self) -> str:
+        auth = self._auth.get_credentials()
+        return f"Macaroon {auth}"
 
     def _candid_discharge(self, macaroon: str) -> str:
         bakery_macaroon = bakery.Macaroon.from_dict(json.loads(macaroon))
@@ -122,7 +110,7 @@ class StoreClient(HTTPClient):
         return base64.urlsafe_b64encode(discharged_macaroons.encode()).decode("ascii")
 
     def _authorize_token(self, candid_discharged_macaroon: str) -> str:
-        token_exchange_response = super().request(
+        token_exchange_response = self.http_client.request(
             "POST",
             self._base_url + self._endpoints.tokens_exchange,
             headers={"Macaroons": candid_discharged_macaroon},
@@ -131,99 +119,6 @@ class StoreClient(HTTPClient):
 
         return token_exchange_response.json()["macaroon"]
 
-    def login(
-        self,
-        *,
-        permissions: Sequence[str],
-        description: str,
-        ttl: int,
-        packages: Optional[Sequence[endpoints.Package]] = None,
-        channels: Optional[Sequence[str]] = None,
-    ) -> str:
-        """Obtain credentials to perform authenticated requests.
-
-        Credentials are stored on the systems keyring, handled by
-        :data:`craft_store.auth.Auth`.
-
-        The list of permissions to select from can be referred to on
-        :data:`craft_store.attenuations`.
-
-        The login process requires 3 steps:
-
-        - request an initial macaroon on :attr:`.endpoints.Endpoints.tokens`.
-        - discharge that macaroon using Candid
-        - send the discharge macaroon to :attr:`.endpoints.Endpoints.tokens_exchange`
-          to obtain final authorization of the macaroon
-
-        This last macaroon is stored into the systems keyring to
-        perform authenticated requests.
-
-        :param permissions: Set of permissions to grant the login.
-        :param description: Client description to refer to from the Store.
-        :param ttl: time to live for the credential, in other words, how
-                    long until it expires, expressed in seconds.
-        :param packages: Sequence of packages to limit the credentials to.
-        :param channels: Sequence of channel names to limit the credentials to.
-        """
-        token_request = self._endpoints.get_token_request(
-            permissions=permissions,
-            description=description,
-            ttl=ttl,
-            packages=packages,
-            channels=channels,
-        )
-
-        macaroon = self._get_macaroon(token_request)
-        candid_discharged_macaroon = self._candid_discharge(macaroon)
-        store_authorized_macaroon = self._authorize_token(candid_discharged_macaroon)
-
-        # Save the authorization token.
-        self._auth.set_credentials(store_authorized_macaroon)
-
-        return self._auth.encode_credentials(store_authorized_macaroon)
-
-    def request(
-        self,
-        method: str,
-        url: str,
-        params: Dict[str, str] = None,
-        headers: Dict[str, str] = None,
-        **kwargs,
-    ) -> requests.Response:
-        """Perform an authenticated request if auth_headers are True.
-
-        :param method: HTTP method used for the request.
-        :param url: URL to request with method.
-        :param params: Query parameters to be sent along with the request.
-        :param headers: Headers to be sent along with the request.
-
-        :raises errors.StoreServerError: for error responses.
-        :raises errors.NetworkError: for lower level network issues.
-        :raises errors.NotLoggedIn: if not logged in.
-
-        :return: Response from the request.
-        """
-        if headers is None:
-            headers = {}
-
-        auth = self._auth.get_credentials()
-        headers["Authorization"] = f"Macaroon {auth}"
-
-        return super().request(
-            method,
-            url,
-            params=params,
-            headers=headers,
-            **kwargs,
-        )
-
-    def whoami(self) -> Dict[str, Any]:
-        """Return whoami json data queyring :attr:`.endpoints.Endpoints.whoami`."""
-        return self.request("GET", self._base_url + self._endpoints.whoami).json()
-
-    def logout(self) -> None:
-        """Clear credentials.
-
-        :raises errors.NotLoggedIn: if not logged in.
-        """
-        self._auth.del_credentials()
+    def _get_discharged_macaroon(self, root_macaroon: str, **kwargs) -> str:
+        candid_discharged_macaroon = self._candid_discharge(root_macaroon)
+        return self._authorize_token(candid_discharged_macaroon)

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     pydantic
     keyring
     macaroonbakery
+    overrides
     requests
 
 [options.package_data]

--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -70,7 +70,7 @@ def http_client_request_mock(real_macaroon):
         return response
 
     patched_http_client = patch(
-        "craft_store.store_client.HTTPClient.request",
+        "craft_store.base_client.HTTPClient.request",
         autospec=True,
         side_effect=request,
     )
@@ -101,7 +101,7 @@ def bakery_discharge_mock(monkeypatch):
 
 @pytest.fixture
 def auth_mock(real_macaroon):
-    patched_auth = patch("craft_store.store_client.Auth", autospec=True)
+    patched_auth = patch("craft_store.base_client.Auth", autospec=True)
     mocked_auth = patched_auth.start()
     mocked_auth.return_value.get_credentials.return_value = real_macaroon
     mocked_auth.return_value.encode_credentials.return_value = "c2VjcmV0LWtleXM="
@@ -132,9 +132,10 @@ def test_store_client_login(
     assert credentials == "c2VjcmV0LWtleXM="
     assert http_client_request_mock.mock_calls == [
         call(
-            store_client,
+            store_client.http_client,
             "POST",
             "https://fake-server.com/v1/tokens",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
             json={
                 "permissions": ["perm-1", "perm-2"],
                 "description": "fakecraft@foo",
@@ -142,7 +143,7 @@ def test_store_client_login(
             },
         ),
         call(
-            store_client,
+            store_client.http_client,
             "POST",
             "https://fake-server.com/v1/tokens/exchange",
             headers={
@@ -183,9 +184,10 @@ def test_store_client_login_with_packages_and_channels(
     assert credentials == "c2VjcmV0LWtleXM="
     assert http_client_request_mock.mock_calls == [
         call(
-            store_client,
+            store_client.http_client,
             "POST",
             "https://fake-server.com/v1/tokens",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
             json={
                 "permissions": ["perm-1", "perm-2"],
                 "description": "fakecraft@foo",
@@ -204,7 +206,7 @@ def test_store_client_login_with_packages_and_channels(
             },
         ),
         call(
-            store_client,
+            store_client.http_client,
             "POST",
             "https://fake-server.com/v1/tokens/exchange",
             headers={
@@ -249,7 +251,7 @@ def test_store_client_request(http_client_request_mock, real_macaroon, auth_mock
 
     assert http_client_request_mock.mock_calls == [
         call(
-            store_client,
+            store_client.http_client,
             "GET",
             "https://fake-server.com/fakepath",
             params=None,
@@ -279,7 +281,7 @@ def test_store_client_whoami(http_client_request_mock, real_macaroon, auth_mock)
 
     assert http_client_request_mock.mock_calls == [
         call(
-            store_client,
+            store_client.http_client,
             "GET",
             "https://fake-server.com/v1/whoami",
             params=None,


### PR DESCRIPTION
The BaseClient is reusable between the Candid flow and the Ubuntu One
flow. Required implementation is done with an AbstractBaseClass and
abstractmethods to ensure the implementor does the right thing.

The BaseClient now also composes the HTTPClient instead of inheriting
from it to make it easier for subclassess to make unauthenticated http
calls without needing to change the signature for .request.

The overrides package was addedd to help pydocstyle not request
docstrings for overriden classes which also triggered pylint's
duplicate-code check (which is in any case disabled as the bigger
signatures in the methods also trigger it).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----