### PR TITLE
endpoints: update whoami endpoint for CHARMHUB (CRAFT-702)

### DIFF
--- a/craft_store/endpoints.py
+++ b/craft_store/endpoints.py
@@ -126,7 +126,7 @@ class _SnapStoreEndpoints(Endpoints):
 
 
 CHARMHUB: Final = Endpoints(
-    whoami="/v1/whoami",
+    whoami="/v1/tokens/whoami",
     tokens="/v1/tokens",
     tokens_exchange="/v1/tokens/exchange",
     valid_package_types=["charm", "bundle"],

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -24,7 +24,7 @@ def test_charmhub():
 
     assert charmhub.tokens == "/v1/tokens"
     assert charmhub.tokens_exchange == "/v1/tokens/exchange"
-    assert charmhub.whoami == "/v1/whoami"
+    assert charmhub.whoami == "/v1/tokens/whoami"
     assert charmhub.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",

--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -283,7 +283,7 @@ def test_store_client_whoami(http_client_request_mock, real_macaroon, auth_mock)
         call(
             store_client.http_client,
             "GET",
-            "https://fake-server.com/v1/whoami",
+            "https://fake-server.com/v1/tokens/whoami",
             params=None,
             headers={"Authorization": f"Macaroon {real_macaroon}"},
         )


### PR DESCRIPTION
Charmhub has introduced a new endpoint for whoami which can provide
token information for the current authorizations used.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----