### PR TITLE
auth: avoid MemoryKeyring in keyring and raise appropriately (CRAFT-771)

### DIFF
--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -33,7 +33,8 @@ logger = logging.getLogger(__name__)
 class MemoryKeyring(keyring.backend.KeyringBackend):
     """A keyring that stores credentials in a dictionary."""
 
-    priority = 1  # type: ignore
+    # Only > 0 make it to the chainer.
+    priority = -1  # type: ignore
 
     def __init__(self) -> None:
         super().__init__()

--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -23,6 +23,7 @@ from typing import Dict, Optional, Tuple
 
 import keyring
 import keyring.backend
+import keyring.backends.fail
 import keyring.errors
 
 from . import errors
@@ -96,6 +97,9 @@ class Auth:
             keyring.set_keyring(MemoryKeyring())
 
         self._keyring = keyring.get_keyring()
+        # This keyring would fail on first use, fail early instead.
+        if isinstance(self._keyring, keyring.backends.fail.Keyring):
+            raise errors.NoKeyringError()
 
         if environment_auth_value:
             self.set_credentials(self.decode_credentials(environment_auth_value))

--- a/craft_store/errors.py
+++ b/craft_store/errors.py
@@ -140,6 +140,13 @@ class NotLoggedIn(CraftStoreError):
         super().__init__("Not logged in.")
 
 
+class NoKeyringError(CraftStoreError):
+    """Error raised when no keyring can be used."""
+
+    def __init__(self) -> None:
+        super().__init__("No keyring found to store or retrieve credentials from.")
+
+
 class CandidTokenTimeoutError(CraftStoreError):
     """Error raised when timeout is reached trying to discharge a macaroon."""
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -19,6 +19,7 @@ from typing import Any, List, Optional, Tuple
 from unittest.mock import ANY, patch
 
 import keyring
+import keyring.backends.fail
 import keyring.errors
 import pytest
 
@@ -198,6 +199,13 @@ def test_environment_set(monkeypatch, fake_keyring, keyring_set_keyring_mock):
     assert fake_keyring.set_password_calls == [
         ("fakeclient", "fakestore.com", "c2VjcmV0LWtleXM=")
     ]
+
+
+def test_no_keyring_get(fake_keyring_get):
+    fake_keyring_get.return_value = keyring.backends.fail.Keyring()
+
+    with pytest.raises(errors.NoKeyringError):
+        Auth("fakeclient", "fakestore.com")
 
 
 def test_memory_keyring_set_get():

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -66,6 +66,11 @@ scenarios = (
         "expected_message": "Issue encountered while processing your request: [501] not implemented.",
     },
     {
+        "exception_class": errors.NoKeyringError,
+        "args": [],
+        "expected_message": "No keyring found to store or retrieve credentials from.",
+    },
+    {
         "exception_class": errors.NotLoggedIn,
         "args": [],
         "expected_message": "Not logged in.",

--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -115,7 +115,7 @@ def bakery_discharge_mock(monkeypatch):
     monkeypatch.setattr(bakery, "discharge_all", mock_discharge)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def auth_mock(real_macaroon):
     patched_auth = patch("craft_store.base_client.Auth", autospec=True)
     mocked_auth = patched_auth.start()


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
With this change, the StoreClient raises on __init__ if no keyring is found.