### PR TITLE
store client: use netloc to reference keyring location (CRAFT-799)

### DIFF
--- a/craft_store/base_client.py
+++ b/craft_store/base_client.py
@@ -58,10 +58,13 @@ class BaseClient(metaclass=ABCMeta):
 
         self._base_url = base_url
         self._storage_base_url = storage_base_url
-        self._store_host = urlparse(base_url).netloc
         self._endpoints = endpoints
 
-        self._auth = Auth(application_name, base_url, environment_auth=environment_auth)
+        self._auth = Auth(
+            application_name,
+            urlparse(base_url).netloc,
+            environment_auth=environment_auth,
+        )
 
     @abstractmethod
     def _get_discharged_macaroon(self, root_macaroon: str, **kwargs) -> str:

--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -171,7 +171,7 @@ def test_store_client_login(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=environment_auth),
+        call("fakecraft", "fake-server.com", environment_auth=environment_auth),
         call().ensure_no_credentials(),
         call().set_credentials(real_macaroon),
         call().encode_credentials(real_macaroon),
@@ -236,7 +236,7 @@ def test_store_client_login_with_packages_and_channels(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().ensure_no_credentials(),
         call().set_credentials(real_macaroon),
         call().encode_credentials(real_macaroon),
@@ -255,7 +255,7 @@ def test_store_client_logout(auth_mock):
     store_client.logout()
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().del_credentials(),
     ]
 
@@ -282,7 +282,7 @@ def test_store_client_request(http_client_request_mock, real_macaroon, auth_mock
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().get_credentials(),
     ]
 
@@ -313,7 +313,7 @@ def test_store_client_whoami(http_client_request_mock, real_macaroon, auth_mock)
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().get_credentials(),
     ]
 

--- a/tests/unit/test_ubuntu_one_store_client.py
+++ b/tests/unit/test_ubuntu_one_store_client.py
@@ -188,7 +188,7 @@ def test_store_client_login(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=environment_auth),
+        call("fakecraft", "fake-server.com", environment_auth=environment_auth),
         call().ensure_no_credentials(),
         call().set_credentials(credentials),
         call().encode_credentials(credentials),
@@ -281,7 +281,7 @@ def test_store_client_login_otp(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         # First call without otp.
         call().ensure_no_credentials(),
         # Second call with otp.
@@ -356,7 +356,7 @@ def test_store_client_login_with_packages_and_channels(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().ensure_no_credentials(),
         call().set_credentials(credentials),
         call().encode_credentials(credentials),
@@ -376,7 +376,7 @@ def test_store_client_logout(auth_mock):
     store_client.logout()
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().del_credentials(),
     ]
 
@@ -404,7 +404,7 @@ def test_store_client_request(http_client_request_mock, authorization, auth_mock
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().get_credentials(),
     ]
 
@@ -448,7 +448,7 @@ def test_store_client_request_refresh(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().get_credentials(),
         call().get_credentials(),
         call().set_credentials(credentials),
@@ -485,6 +485,6 @@ def test_store_client_whoami(http_client_request_mock, authorization, auth_mock)
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "https://fake-server.com", environment_auth=None),
+        call("fakecraft", "fake-server.com", environment_auth=None),
         call().get_credentials(),
     ]


### PR DESCRIPTION
This was somehow missed, as seen from the unsused attribute which is now removed
and processed when passing the "host" parameter to Auth.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
This does have the drawback of forgetting of forgetting about existing logins.