### PR TITLE
auth: raise error when credentials cannot be parsed (CRAFT-812)

### DIFF
--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -17,6 +17,7 @@
 """Craft Store Authentication Store."""
 
 import base64
+import binascii
 import logging
 import os
 from typing import Dict, Optional, Tuple
@@ -106,8 +107,14 @@ class Auth:
 
     @staticmethod
     def decode_credentials(encoded_credentials: str) -> str:
-        """Decode base64 encoded credentials."""
-        return base64.b64decode(encoded_credentials).decode()
+        """Decode base64 encoded credentials.
+
+        :raises errors.CredentialsNotParseable: when the credentials are incorrectly encoded.
+        """
+        try:
+            return base64.b64decode(encoded_credentials).decode()
+        except binascii.Error as err:
+            raise errors.CredentialsNotParseable from err
 
     @staticmethod
     def encode_credentials(credentials: str) -> str:

--- a/craft_store/errors.py
+++ b/craft_store/errors.py
@@ -147,6 +147,15 @@ class CredentialsUnavailable(CraftStoreError):
         super().__init__(f"No credentials found for {application!r} on {host!r}.")
 
 
+class CredentialsNotParseable(CraftStoreError):
+    """Error raised when credentials are not parseable."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Credentials could not be parsed. Expected base64 encoded credentials."
+        )
+
+
 class NoKeyringError(CraftStoreError):
     """Error raised when no keyring can be used."""
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -205,6 +205,13 @@ def test_del_credentials_gets_no_credential(caplog, fake_keyring):
     ] == [rec.message for rec in caplog.records]
 
 
+def test_credentials_not_parseable_error(monkeypatch):
+    monkeypatch.setenv("FAKE_ENV", "12345")
+
+    with pytest.raises(errors.CredentialsNotParseable):
+        Auth("fakeclient", "fakestore.com", environment_auth="FAKE_ENV")
+
+
 def test_environment_set(monkeypatch, fake_keyring, keyring_set_keyring_mock):
     monkeypatch.setenv("FAKE_ENV", "c2VjcmV0LWtleXM=")
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -81,6 +81,11 @@ scenarios = (
         "expected_message": "No credentials found for 'mycraft' on 'my.host.com'.",
     },
     {
+        "exception_class": errors.CredentialsNotParseable,
+        "args": [],
+        "expected_message": "Credentials could not be parsed. Expected base64 encoded credentials.",
+    },
+    {
         "exception_class": errors.CandidTokenTimeoutError,
         "args": ["https://foo.bar"],
         "expected_message": "Timed out waiting for token response from 'https://foo.bar'.",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
 
`craft-store` to raise a more useful error when a credential is not parseable. 

Previous Behavior:
```
> > CHARMCRAFT_AUTH='12345' charmcraft login
charmcraft internal error: Error('Invalid base64-encoded string: number of data characters (5) cannot be 1 more than a multiple of 4')
```

New Behavior:
```
> CHARMCRAFT_AUTH='12345' charmcraft login
charmcraft internal error: CredentialsNotParseable('Credentials could not be parsed.')
```

https://github.com/canonical/craft-store/issues/20