### PR TITLE
ubuntu client: proper refresh macaroon

### DIFF
--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -131,12 +131,14 @@ class Auth:
         if self._keyring.get_password(self.application_name, self.host) is not None:
             raise errors.CredentialsAlreadyAvailable(self.application_name, self.host)
 
-    def set_credentials(self, credentials: str) -> None:
+    def set_credentials(self, credentials: str, force: bool = False) -> None:
         """Store credentials in the keyring.
 
         :param credentials: token to store.
+        :param force: overwrite existing credentials.
         """
-        self.ensure_no_credentials()
+        if not force:
+            self.ensure_no_credentials()
 
         logger.debug(
             "Storing credentials for %r on %r in keyring %r.",

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -120,6 +120,19 @@ def test_double_set_credentials_fails():
         auth.set_credentials("{'password': 'secret'}")
 
 
+def test_double_set_credentials_force(fake_keyring):
+    auth = Auth("fakeclient", "fakestore.com")
+
+    auth.set_credentials("{'password': 'secret'}")
+
+    auth.set_credentials("{'password': 'secret2'}", force=True)
+
+    assert fake_keyring.set_password_calls == [
+        ("fakeclient", "fakestore.com", "eydwYXNzd29yZCc6ICdzZWNyZXQnfQ=="),
+        ("fakeclient", "fakestore.com", "eydwYXNzd29yZCc6ICdzZWNyZXQyJ30="),
+    ]
+
+
 def test_get_credentials(caplog, fake_keyring):
     fake_keyring.password = "eydwYXNzd29yZCc6ICdzZWNyZXQnfQ=="
 


### PR DESCRIPTION
Whislt the original implementation which was used in Snapcraft had the
Snap Store return a header with refresh information, the new backend
returns an error code.

This allows for macaroons to be refreshed properly by adding a force
option to set_credentials.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
