### PR TITLE
auth: handle keyring unlocking errors

### DIFF
--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -127,9 +127,15 @@ class Auth:
         """Check that no credentials exist.
 
         :raises errors.CredentialsAvailable: if credentials have already been set.
+        :raises errors.KeyringUnlockError: if the keyring cannot be unlocked.
         """
-        if self._keyring.get_password(self.application_name, self.host) is not None:
-            raise errors.CredentialsAlreadyAvailable(self.application_name, self.host)
+        try:
+            if self._keyring.get_password(self.application_name, self.host) is not None:
+                raise errors.CredentialsAlreadyAvailable(
+                    self.application_name, self.host
+                )
+        except keyring.errors.KeyringLocked:
+            raise errors.KeyringUnlockError()
 
     def set_credentials(self, credentials: str, force: bool = False) -> None:
         """Store credentials in the keyring.

--- a/craft_store/errors.py
+++ b/craft_store/errors.py
@@ -161,6 +161,16 @@ class NoKeyringError(CraftStoreError):
         super().__init__("No keyring found to store or retrieve credentials from.")
 
 
+class KeyringUnlockError(CraftStoreError):
+    """Error raised when keyring unlocking fails."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Failed to unlock the keyring.",
+            resolution="Make sure the password is correct and the keyring is available.",
+        )
+
+
 class CandidTokenTimeoutError(CraftStoreError):
     """Error raised when timeout is reached trying to discharge a macaroon."""
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -238,6 +238,17 @@ def test_environment_set(monkeypatch, fake_keyring, keyring_set_keyring_mock):
     ]
 
 
+def test_ensure_no_credentials_unlock_error(fake_keyring, mocker):
+    mocker.patch.object(
+        fake_keyring, "get_password", side_effect=errors.KeyringUnlockError
+    )
+
+    auth = Auth("fakeclient", "fakestore.com")
+
+    with pytest.raises(errors.KeyringUnlockError):
+        auth.ensure_no_credentials()
+
+
 @pytest.mark.disable_fake_keyring
 def test_ephemeral_set_memory_keyring():
     auth = Auth("fakeclient", "fakestore.com", ephemeral=True)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -71,6 +71,11 @@ scenarios = (
         "expected_message": "No keyring found to store or retrieve credentials from.",
     },
     {
+        "exception_class": errors.KeyringUnlockError,
+        "args": [],
+        "expected_message": "Failed to unlock the keyring.",
+    },
+    {
         "exception_class": errors.CredentialsAlreadyAvailable,
         "args": ["mycraft", "my.host.com"],
         "expected_message": "Credentials found for 'mycraft' on 'my.host.com'.",


### PR DESCRIPTION
Obtaining the password from the keyring can fail if the keyring is not properly unlocked. In this case, handle the keyring exception and raise an appropriate Craft-store error.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1622