### PR TITLE
test: improve integration testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install python packages and dependencies
@@ -44,17 +44,17 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [macos-12, ubuntu-18.04, ubuntu-20.04, windows-2019]
+        os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
         python-version: ["3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 packages = find:
 zip_safe = False
 install_requires =
-    pydantic
+    pydantic>=1.10
     keyring>=23.0
     macaroonbakery
     overrides
@@ -63,6 +63,7 @@ test =
     pytest-check
     pytest-mock
     pytest-subprocess
+    pytest-timeout>=2.0
     tox
     types-requests
     types-setuptools

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,8 +13,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import os
 import shutil
+import uuid
 from pathlib import Path
 
 import pytest
@@ -37,7 +38,17 @@ def charm_client():
 
 
 @pytest.fixture
-def fake_charm_file(tmpdir):
+def charmhub_charm_name():
+    """Allow overriding the user to override the test charm.
+
+    NOTE: Most integration tests check specifics about craft-store-test-charm,
+    so overriding the test charm may cause test failures.
+    """
+    yield os.getenv("CRAFT_STORE_TEST_CHARM", default="craft-store-test-charm")
+
+
+@pytest.fixture
+def fake_charm_file(tmpdir, charmhub_charm_name):
     """Provide a fake charm to upload to charmhub."""
     # Make tmpdir Path instead of Path-like.
     prime_dir = Path(tmpdir) / "prime"
@@ -47,7 +58,7 @@ def fake_charm_file(tmpdir):
     with medadata_path.open("w") as metadata_file:
         yaml.safe_dump(
             data={
-                "name": "craft-store-test-charm",
+                "name": charmhub_charm_name,
                 "display-name": "display",
                 "description": "description",
                 "summary": "summary",
@@ -90,3 +101,21 @@ def fake_charm_file(tmpdir):
         )
 
         return charm_file
+
+
+@pytest.fixture
+def unregistered_charm_name(charm_client):
+    """Get an unregistered name for use in tests"""
+    account_id = charm_client.whoami().get("account", {}).get("id", "").lower()
+    registered_names = {result.name for result in charm_client.list_registered_names()}
+    while (name := f"test-{account_id}-{uuid.uuid4()}") in registered_names:
+        # Regenerate UUIDs until we find one that's not registered or timeout.
+        pass
+    yield name
+
+
+def needs_charmhub_credentials():
+    return pytest.mark.skipif(
+        not os.getenv("CRAFT_STORE_CHARMCRAFT_CREDENTIALS"),
+        reason="CRAFT_STORE_CHARMCRAFT_CREDENTIALS are not set",
+    )

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -22,6 +22,8 @@ import pytest
 from craft_store import errors
 from craft_store.auth import Auth, MemoryKeyring
 
+pytestmark = pytest.mark.timeout(10)  # Timeout if any test takes over 10 sec.
+
 
 @pytest.fixture
 def test_keyring():

--- a/tests/integration/test_get_list_releases.py
+++ b/tests/integration/test_get_list_releases.py
@@ -16,22 +16,22 @@
 
 
 import datetime
-import os
 from typing import cast
 
 import pytest
 
 from craft_store.models import charm_list_releases_model
 
+from .conftest import needs_charmhub_credentials
 
-@pytest.mark.skipif(
-    not os.getenv("CRAFT_STORE_CHARMCRAFT_CREDENTIALS"),
-    reason="CRAFT_STORE_CHARMCRAFT_CREDENTIALS are not set",
-)
-def test_charm_get_list_releases(charm_client):
+pytestmark = pytest.mark.timeout(10)  # Timeout if any test takes over 10 sec.
+
+
+@needs_charmhub_credentials()
+def test_charm_get_list_releases(charm_client, charmhub_charm_name):
     model = cast(
         charm_list_releases_model.ListReleasesModel,
-        charm_client.get_list_releases(name="craft-store-test-charm"),
+        charm_client.get_list_releases(name=charmhub_charm_name),
     )
 
     assert len(model.channel_map) == 1

--- a/tests/integration/test_release.py
+++ b/tests/integration/test_release.py
@@ -13,25 +13,22 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-
-import os
-
 import pytest
 
 from craft_store.models import release_request_model
 
+from .conftest import needs_charmhub_credentials
 
-@pytest.mark.skipif(
-    not os.getenv("CRAFT_STORE_CHARMCRAFT_CREDENTIALS"),
-    reason="CRAFT_STORE_CHARMCRAFT_CREDENTIALS are not set",
-)
-def test_charm_release(charm_client):
+pytestmark = pytest.mark.timeout(10)  # Timeout if any test takes over 10 sec.
+
+
+@needs_charmhub_credentials()
+def test_charm_release(charm_client, charmhub_charm_name):
     model = release_request_model.ReleaseRequestModel(
         channel="edge", revision=1, resources=[]
     )
 
     charm_client.release(
-        name="craft-store-test-charm",
+        name=charmhub_charm_name,
         release_request=[model],
     )


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

We should probably get a service account for charmhub, but in the meantime this improves the testing a bit.

Outstanding issue: Charmhub credentials aren't used when running with a PR from an external repository, so it skips tests that require charmhub credentials. However, those tests will run on merge to main.