### PR TITLE
feat: add file based backend as a fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,9 @@ line_length = 88
 minversion = "7.0"
 testpaths = "tests"
 xfail_strict = true
+markers = [
+    "disable_fake_keyring"
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "requests-toolbelt>=1.0.0",
     "macaroonbakery>=1.3.0",
     "pydantic>=1.10,<2.0",
+    "pyxdg",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,9 +15,68 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+from typing import Any, List, Optional, Tuple
 from unittest.mock import patch
 
 import pytest
+
+
+class FakeKeyring:
+    """Fake Keyring Backend implementation for tests."""
+
+    name = "Fake Keyring"
+
+    def __init__(self) -> None:
+        self.set_password_calls: List[Tuple[Any, ...]] = []
+        self.get_password_calls: List[Tuple[Any, ...]] = []
+        self.delete_password_calls: List[Tuple[Any, ...]] = []
+        self.password = None
+        self.delete_error: Optional[Exception] = None
+
+    def set_password(self, *args) -> None:
+        """Set the service password for username in memory."""
+        self.set_password_calls.append(args)
+        self.password = args[2]
+
+    def get_password(self, *args):
+        """Get the service password for username from memory."""
+        self.get_password_calls.append(args)
+        return self.password
+
+    def delete_password(self, *args):
+        """Delete the service password for username from memory."""
+        self.delete_password_calls.append(args)
+        if self.delete_error is not None:
+            # https://www.logilab.org/ticket/3207
+            raise self.delete_error  # pylint: disable=raising-bad-type
+
+
+@pytest.fixture()
+def keyring_set_keyring_mock():
+    """Mock setting the keyring."""
+
+    patched_keyring = patch("keyring.set_keyring", autospec=True)
+    mocked_keyring = patched_keyring.start()
+    yield mocked_keyring
+    patched_keyring.stop()
+
+
+@pytest.fixture()
+def fake_keyring():
+    return FakeKeyring()
+
+
+@pytest.fixture(autouse=True)
+def fake_keyring_get(fake_keyring, request):
+    """Mock keyring and return a FakeKeyring."""
+    if "disable_fake_keyring" in request.keywords:
+        yield
+    else:
+        patched_keyring = patch("keyring.get_keyring")
+        mocked_keyring = patched_keyring.start()
+        mocked_keyring.return_value = fake_keyring
+        yield mocked_keyring
+        patched_keyring.stop()
 
 
 @pytest.fixture()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -15,8 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Any, List, Optional, Tuple
-from unittest.mock import ANY, patch
+from unittest.mock import ANY
 
 import keyring
 import keyring.backends.fail
@@ -24,64 +23,6 @@ import keyring.errors
 import pytest
 from craft_store import errors
 from craft_store.auth import Auth, MemoryKeyring
-
-
-class FakeKeyring:
-    """Fake Keyring Backend implementation for tests."""
-
-    name = "Fake Keyring"
-
-    def __init__(self) -> None:
-        self.set_password_calls: List[Tuple[Any, ...]] = []
-        self.get_password_calls: List[Tuple[Any, ...]] = []
-        self.delete_password_calls: List[Tuple[Any, ...]] = []
-        self.password = None
-        self.delete_error: Optional[Exception] = None
-
-    def set_password(self, *args) -> None:
-        """Set the service password for username in memory."""
-        self.set_password_calls.append(args)
-        self.password = args[2]
-
-    def get_password(self, *args):
-        """Get the service password for username from memory."""
-        self.get_password_calls.append(args)
-        return self.password
-
-    def delete_password(self, *args):
-        """Delete the service password for username from memory."""
-        self.delete_password_calls.append(args)
-        if self.delete_error is not None:
-            # https://www.logilab.org/ticket/3207
-            raise self.delete_error  # pylint: disable=raising-bad-type
-
-
-@pytest.fixture()
-def keyring_set_keyring_mock():
-    """Mock setting the keyring."""
-
-    patched_keyring = patch("keyring.set_keyring", autospec=True)
-    mocked_keyring = patched_keyring.start()
-    yield mocked_keyring
-    patched_keyring.stop()
-
-
-@pytest.fixture()
-def fake_keyring():
-    return FakeKeyring()
-
-
-@pytest.fixture(autouse=True)
-def fake_keyring_get(fake_keyring, request):
-    """Mock keyring and return a FakeKeyring."""
-    if "disable_fake_keyring" in request.keywords:
-        yield
-    else:
-        patched_keyring = patch("keyring.get_keyring")
-        mocked_keyring = patched_keyring.start()
-        mocked_keyring.return_value = fake_keyring
-        yield mocked_keyring
-        patched_keyring.stop()
 
 
 def test_set_credentials(caplog, fake_keyring):


### PR DESCRIPTION
Useful when a keyring is not available, such as when running on a headless system.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
Fixes #109 #58 