### PR TITLE
chore(deps): don't let renovate update pydantic or protobuf

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,10 @@
 {
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:base"],
+  ignoreDeps: [
+    "pydantic",  // We need to update everything to pydantic 2 simultaneously.
+    "protobuf",  // See: https://github.com/canonical/craft-store/issues/132
+  ],
   labels: ["dependencies"],  // For convenient searching in GitHub
   pip_requirements: {
     fileMatch: ["^tox.ini$", "(^|/)requirements([\\w-]*)\\.txt$"]


### PR DESCRIPTION
We'd be ignoring these updates anyway, so let's just prevent Renovate from doing them.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
