### PR TITLE
fix: workaround for keyring 25 incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Canonical Ltd.", email = "snapcraft@lists.snapcraft.io"},
 ]
 dependencies = [
-    "keyring>=23.0",
+    "keyring>=23.0,<25.0",  # https://github.com/canonical/craft-store/issues/162
     "overrides>=7.0.0",
     "requests>=2.27.0",
     "requests-toolbelt>=1.0.0",


### PR DESCRIPTION
https://github.com/canonical/craft-store/issues/162

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
