### PR TITLE
Release 2.6.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.1
+current_version = 2.6.2
 commit = False
 tag = False
 

--- a/craft_store/__init__.py
+++ b/craft_store/__init__.py
@@ -16,7 +16,7 @@
 
 """Interact with Canonical services such as Charmhub and the Snap Store."""
 
-__version__ = "2.6.1"
+__version__ = "2.6.2"
 
 
 from . import creds, endpoints, errors, models

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -6,6 +6,7 @@ https
 io
 initialization
 initialized
+libssl
 NotLoggedIn
 keyring
 StoreClient

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 *********
 Changelog
 *********
+
+2.6.2 (2024-05-06)
+------------------
+
+- Disable legacy libssl providers. This is a workaround to prevent a crash
+  when loading cryptography in focal.
+
 2.6.1 (2024-03-26)
 ------------------
 


### PR DESCRIPTION
# Changelog

- Disable legacy libssl providers. This is a workaround to prevent a crash
  when loading cryptography in focal.