### PR TITLE
style(lint): autofix ruff 0.6.4 linting errors

### DIFF
--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -384,7 +384,7 @@ def test_store_client_upload_file_with_monitor(tmp_path, http_client_request_moc
     filepath = tmp_path / "artifact.thing"
     filepath.write_text("file to upload")
 
-    def callback(monitor):  # noqa: ARG001
+    def callback(monitor):
         pass
 
     def monitor(encoder):  # noqa: ARG001


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

Pipeline currently fails due to the change in the implementation of ARG001 rule ( https://github.com/astral-sh/ruff/issues/12963 )
