### PR TITLE
fix: update discharge macaroons

### DIFF
--- a/craft_store/creds.py
+++ b/craft_store/creds.py
@@ -106,7 +106,7 @@ class UbuntuOneMacaroons(BaseModel):
 
     def with_discharge(self, discharge: str) -> "UbuntuOneMacaroons":
         """Create a copy of this UbuntuOneMacaroons with a different discharge macaroon."""
-        return self.model_copy(update={"d": discharge})
+        return self.model_copy(update={"discharge": discharge})
 
 
 class UbuntuOneModel(BaseModel):

--- a/tests/unit/test_creds.py
+++ b/tests/unit/test_creds.py
@@ -83,6 +83,19 @@ def test_u1_creds_marshal():
     assert loaded["v"]["d"] == "fake discharge"
 
 
+def test_u1_creds_with_discharge():
+    """Return new credentials with an updated discharge macaroon."""
+    original_creds = creds.UbuntuOneMacaroons(r="original root", d="original discharge")
+
+    new_creds = original_creds.with_discharge("new discharge")
+
+    assert original_creds.root == "original root"
+    assert original_creds.discharge == "original discharge"
+    assert new_creds.root == "original root"
+    assert new_creds.discharge == "new discharge"
+
+
+
 def test_u1_creds_unmarshal_failure():
     with pytest.raises(errors.CredentialsNotParseable):
         creds.unmarshal_u1_credentials("not a valid json string")

--- a/tests/unit/test_creds.py
+++ b/tests/unit/test_creds.py
@@ -95,7 +95,6 @@ def test_u1_creds_with_discharge():
     assert new_creds.discharge == "new discharge"
 
 
-
 def test_u1_creds_unmarshal_failure():
     with pytest.raises(errors.CredentialsNotParseable):
         creds.unmarshal_u1_credentials("not a valid json string")


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Pydantic 2's `model_copy()` function cannot update fields by their alias.  

Fixes https://github.com/canonical/snapcraft/issues/5048