### PR TITLE
chore(merge): 2.6.2 into main

### DIFF
--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -30,10 +30,13 @@ import keyring.backend
 import keyring.backends.fail
 import keyring.errors
 from jaraco.classes import properties
-from keyring.backends import SecretService
 from xdg import BaseDirectory  # type: ignore[import]
 
 from . import errors
+
+# workaround to prevent legacy provider loading in focal
+os.environ["CRYPTOGRAPHY_OPENSSL_NO_LEGACY"] = "1"
+from keyring.backends import SecretService
 
 logger = logging.getLogger(__name__)
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -6,6 +6,7 @@ https
 io
 initialization
 initialized
+libssl
 NotLoggedIn
 keyring
 StoreClient

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,12 @@ Breaking changes:
 Bug fixes:
 - Better error message when the keyring is locked.
 
+2.6.2 (2024-05-06)
+------------------
+
+- Disable legacy libssl providers. This is a workaround to prevent a crash
+  when loading cryptography in focal.
+
 2.6.1 (2024-03-26)
 ------------------
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Merges the fix from https://github.com/canonical/craft-store/pull/175 into main.

This explains https://github.com/canonical/snapcraft/issues/5077 because snapcraft 8.3 was using craft-store 2.6.2 and the fix was lost when snapcraft 8.4 upgraded to craft-store 3.0.

We will need a craft-store release after this lands.