### PR TITLE
ci: update permissions for publishing to pypi

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   source-wheel:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

I'm not sure why this is not needed in other repos, but CI is failing: https://github.com/canonical/craft-store/actions/runs/11130571185/job/30933712504