### PR TITLE
feat: add opt-in fallback to FileKeyring

### DIFF
--- a/craft_store/base_client.py
+++ b/craft_store/base_client.py
@@ -67,6 +67,7 @@ class BaseClient(metaclass=ABCMeta):
         user_agent: str,
         environment_auth: str | None = None,
         ephemeral: bool = False,
+        file_fallback: bool = False,
     ) -> None:
         """Initialize the Store Client."""
         self.http_client = HTTPClient(user_agent=user_agent)
@@ -80,6 +81,7 @@ class BaseClient(metaclass=ABCMeta):
             urlparse(base_url).netloc,
             environment_auth=environment_auth,
             ephemeral=ephemeral,
+            file_fallback=file_fallback,
         )
 
     @abstractmethod

--- a/craft_store/store_client.py
+++ b/craft_store/store_client.py
@@ -88,6 +88,7 @@ class StoreClient(BaseClient):
         user_agent: str,
         environment_auth: str | None = None,
         ephemeral: bool = False,
+        file_fallback: bool = False,
     ) -> None:
         super().__init__(
             base_url=base_url,
@@ -97,6 +98,7 @@ class StoreClient(BaseClient):
             user_agent=user_agent,
             environment_auth=environment_auth,
             ephemeral=ephemeral,
+            file_fallback=file_fallback,
         )
 
         self._bakery_client = httpbakery.Client(

--- a/craft_store/ubuntu_one_store_client.py
+++ b/craft_store/ubuntu_one_store_client.py
@@ -42,6 +42,7 @@ class UbuntuOneStoreClient(BaseClient):
         user_agent: str,
         environment_auth: str | None = None,
         ephemeral: bool = False,
+        file_fallback: bool = False,
     ) -> None:
         super().__init__(
             base_url=base_url,
@@ -51,6 +52,7 @@ class UbuntuOneStoreClient(BaseClient):
             user_agent=user_agent,
             environment_auth=environment_auth,
             ephemeral=ephemeral,
+            file_fallback=file_fallback,
         )
         self._auth_url = auth_url
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+3.1.0 (XXXX-XX-XX)
+------------------
+
+- Add opt-in ``FileKeyring`` fallback for ``Auth`` in the case of missing
+  ``SecretService`` provider on a system.
+
+..
+  For a complete list of commits, check out the `3.1.0`_ release on GitHub.
+
 3.0.2 (2024-09-30)
 ------------------
 
@@ -175,3 +184,6 @@ Bug fixes:
 ------------------
 
 - Initial release
+
+
+.. _3.1.0: https://github.com/canonical/craft-store/releases/tag/3.1.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 *********
 
-3.1.0 (XXXX-XX-XX)
+3.1.0 (2024-XX-XX)
 ------------------
 
 - Add opt-in ``FileKeyring`` fallback for ``Auth`` in the case of missing

--- a/tests/unit/test_store_client.py
+++ b/tests/unit/test_store_client.py
@@ -123,8 +123,14 @@ def auth_mock(real_macaroon, new_auth):
 @pytest.mark.usefixtures("_bakery_discharge_mock")
 @pytest.mark.parametrize("ephemeral_auth", [True, False])
 @pytest.mark.parametrize("environment_auth", [None, "APPLICATION_CREDENTIALS"])
+@pytest.mark.parametrize("file_fallback", [True, False])
 def test_store_client_login(
-    http_client_request_mock, real_macaroon, auth_mock, environment_auth, ephemeral_auth
+    http_client_request_mock,
+    real_macaroon,
+    auth_mock,
+    environment_auth,
+    ephemeral_auth,
+    file_fallback,
 ):
     store_client = StoreClient(
         base_url="https://fake-server.com",
@@ -134,6 +140,7 @@ def test_store_client_login(
         user_agent="FakeCraft Unix X11",
         environment_auth=environment_auth,
         ephemeral=ephemeral_auth,
+        file_fallback=file_fallback,
     )
 
     credentials = store_client.login(
@@ -172,6 +179,7 @@ def test_store_client_login(
             "fake-server.com",
             environment_auth=environment_auth,
             ephemeral=ephemeral_auth,
+            file_fallback=file_fallback,
         ),
         call().ensure_no_credentials(),
         call().set_credentials(wrapped),
@@ -240,7 +248,13 @@ def test_store_client_login_with_packages_and_channels(
     expected_credentials = creds.marshal_candid_credentials(real_macaroon)
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().ensure_no_credentials(),
         call().set_credentials(expected_credentials),
         call().encode_credentials(expected_credentials),
@@ -259,7 +273,13 @@ def test_store_client_logout(auth_mock):
     store_client.logout()
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().del_credentials(),
     ]
 
@@ -286,7 +306,13 @@ def test_store_client_request(http_client_request_mock, real_macaroon, auth_mock
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().get_credentials(),
     ]
 
@@ -317,7 +343,13 @@ def test_store_client_whoami(http_client_request_mock, real_macaroon, auth_mock)
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().get_credentials(),
     ]
 

--- a/tests/unit/test_ubuntu_one_store_client.py
+++ b/tests/unit/test_ubuntu_one_store_client.py
@@ -205,6 +205,7 @@ def test_store_client_login(
             "fake-server.com",
             environment_auth=environment_auth,
             ephemeral=False,
+            file_fallback=False,
         ),
         call().ensure_no_credentials(),
         call().set_credentials(new_credentials),
@@ -298,7 +299,13 @@ def test_store_client_login_otp(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         # First call without otp.
         call().ensure_no_credentials(),
         # Second call with otp.
@@ -373,7 +380,13 @@ def test_store_client_login_with_packages_and_channels(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().ensure_no_credentials(),
         call().set_credentials(new_credentials),
         call().encode_credentials(new_credentials),
@@ -393,7 +406,13 @@ def test_store_client_logout(auth_mock):
     store_client.logout()
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().del_credentials(),
     ]
 
@@ -421,7 +440,13 @@ def test_store_client_request(http_client_request_mock, authorization, auth_mock
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().get_credentials(),
     ]
 
@@ -486,7 +511,13 @@ def test_store_client_request_refresh(
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().get_credentials(),
         call().get_credentials(),
         call().set_credentials(new_credentials, force=True),
@@ -523,6 +554,12 @@ def test_store_client_whoami(http_client_request_mock, authorization, auth_mock)
     ]
 
     assert auth_mock.mock_calls == [
-        call("fakecraft", "fake-server.com", environment_auth=None, ephemeral=False),
+        call(
+            "fakecraft",
+            "fake-server.com",
+            environment_auth=None,
+            ephemeral=False,
+            file_fallback=False,
+        ),
         call().get_credentials(),
     ]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

Previously, we were falling back to `FileKeyring` if and only if `SecretService` provider was erroring out, not if it was not available at all.
This PR allows applications to opt-in for fallback to use a file to store secrets in a system without `SecretService` provider.

(CRAFT-3620)


