### PR TITLE
chore(lint): get around pydantic 2.10.x bugs

### DIFF
--- a/craft_store/models/release_request_model.py
+++ b/craft_store/models/release_request_model.py
@@ -41,5 +41,7 @@ class ReleaseRequestModel(MarshableModel):
     """
 
     channel: str
-    resources: list[ResourceModel] | None = Field(default_factory=list)
+    # remove it after upstream is fixed
+    # https://github.com/pydantic/pydantic/issues/10950
+    resources: list[ResourceModel] | None = Field(default_factory=list)  # type: ignore[arg-type]
     revision: int | None = Field(...)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,8 +257,8 @@ select = [  # Base linting rule selections.
     "RSE",  # Errors on pytest raises.
     "RET",  # Simpler logic after return, raise, continue or break
     "SIM",  # Code simplification
-    "TCH004",  # Remove imports from type-checking guard blocks if used at runtime
-    "TCH005",  # Delete empty type-checking blocks
+    "TC004",  # Remove imports from type-checking guard blocks if used at runtime
+    "TC005",  # Delete empty type-checking blocks
     "ARG",  # Unused arguments
     "PTH",  # Migrate to pathlib
     "ERA",  # Don't check in commented out code

--- a/tests/unit/models/test_registered_name_model.py
+++ b/tests/unit/models/test_registered_name_model.py
@@ -16,7 +16,7 @@
 #
 """Tests for RegisteredNameModel."""
 
-import pydantic_core
+import pydantic
 import pytest
 from craft_store.models import (
     AccountModel,
@@ -93,7 +93,9 @@ def test_unmarshal(check, json_dict):
     if actual.website is None:
         check.is_none(json_dict.get("website"))
     else:
-        check.equal(actual.website, pydantic_core.Url(json_dict.get("website")))
+        check.equal(
+            actual.website, pydantic.networks.AnyHttpUrl(json_dict.get("website"))
+        )
     check.equal(
         actual.track_guardrails,
         [


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

Silent error, that was introduced with pydantic 2.10 release until it's fixed.

For reference: https://github.com/pydantic/pydantic/issues/10950
https://github.com/canonical/craft-application/pull/566

There was also a change in `pydantic_core`, which made `Url` incomparable with `AnyHttpUrl`. Somehow in my local environment it only failed when tests were run through `tox`, not directly. From test logs:
```
FAILURE: check https://canonical.com/ == https://canonical.com/
test_registered_name_model.py:99 in test_unmarshal() -> check.equal(actual.website, pydantic.networks.HttpUrl(json_dict.get("website")))
```

