### PR TITLE
build(deps): update Jinja2

### DIFF
--- a/craft_store/store_client.py
+++ b/craft_store/store_client.py
@@ -75,7 +75,7 @@ class WebBrowserWaitingInteractor(httpbakery.WebBrowserInteractor):  # type: ign
 class StoreClient(BaseClient):
     """Encapsulates API calls for the Snap Store or Charmhub."""
 
-    TOKEN_TYPE: str = "macaroon"
+    TOKEN_TYPE: str = "macaroon"  # noqa: S105
 
     @overrides
     def __init__(

--- a/craft_store/ubuntu_one_store_client.py
+++ b/craft_store/ubuntu_one_store_client.py
@@ -29,7 +29,7 @@ from .base_client import BaseClient
 class UbuntuOneStoreClient(BaseClient):
     """Encapsulates API calls for the Snap Store or Charmhub with Ubuntu One."""
 
-    TOKEN_TYPE: str = "u1-macaroon"
+    TOKEN_TYPE: str = "u1-macaroon"  # noqa: S105
 
     def __init__(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -430,7 +430,7 @@ toml = [
 
 [[package]]
 name = "craft-store"
-version = "3.0.2.post32+g7399526.d20241216"
+version = "3.1.0.post2+g9347a4a.d20250108"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },
@@ -822,14 +822,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369", size = 240245 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d", size = 133271 },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
 ]
 
 [[package]]


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

Fixes currently failing pipeline in `craft-store`.

* Update Jinja2 dependency to address CVE scanning result.
* Disable `S105` false-positive for the `TOKEN_TYPE` 
