### PR TITLE
fix(publishergateway): used the wrong resource model

### DIFF
--- a/craft_store/publisher/_response.py
+++ b/craft_store/publisher/_response.py
@@ -166,9 +166,16 @@ class Releases(_base_model.MarshableModel):
     )
 
 
+class ReleasedResourceRevision(_base_model.MarshableModel):
+    """A resource revision attached to a release."""
+
+    name: str
+    revision: int | None = None
+
+
 class ReleaseResult(_base_model.MarshableModel):
     """The result of a single release request."""
 
     channel: str | None = None
     revision: int | None = None
-    resources: list[Resource] | None = None
+    resources: list[ReleasedResourceRevision] | None = None

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+3.2.1 (2025-02-03)
+------------------
+
+- Fix a bug on the ``PublisherGateway`` client that could cause releases containing
+  resources to fail.
+
+For a complete list of commits, check out the `3.2.1`_ release on GitHub.
+
 3.2.0 (2025-01-24)
 ------------------
 
@@ -198,3 +206,4 @@ Bug fixes:
 
 .. _3.1.0: https://github.com/canonical/craft-store/releases/tag/3.1.0
 .. _3.2.0: https://github.com/canonical/craft-store/releases/tag/3.2.0
+.. _3.2.1: https://github.com/canonical/craft-store/releases/tag/3.2.1

--- a/tests/unit/publisher/test_publishergateway.py
+++ b/tests/unit/publisher/test_publishergateway.py
@@ -25,6 +25,7 @@ import pytest
 import pytest_check
 from craft_store import errors, publisher
 from craft_store.publisher import RegisteredName, ReleaseResult, Revision
+from craft_store.publisher._response import ReleasedResourceRevision
 
 
 @pytest.fixture
@@ -379,6 +380,25 @@ def test_list_revisions_parameters(
         pytest.param(
             [{"channel": "latest/edge", "revision": 123}],
             [ReleaseResult(channel="latest/edge", revision=123)],
+        ),
+        pytest.param(
+            [
+                {
+                    "channel": "latest/edge",
+                    "revision": 123,
+                    "resources": [{"name": "my-resource", "revision": 456}],
+                }
+            ],
+            [
+                ReleaseResult(
+                    channel="latest/edge",
+                    revision=123,
+                    resources=[
+                        ReleasedResourceRevision(name="my-resource", revision=456)
+                    ],
+                )
+            ],
+            id="with_resource",
         ),
     ],
 )


### PR DESCRIPTION
I used the wrong resource model causing failures during release if the store doesn't return a type.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

-----

CRAFT-4032