### PR TITLE
build(deps): constrain the minimum version of sphinx-rtd-theme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
     "sphinx-lint==1.0.0",
     "sphinx-notfound-page==1.1.0",
     "sphinx-reredirects==0.1.5",
-    "sphinx-rtd-theme",
+    "sphinx-rtd-theme>=3.0",
     "sphinx-tabs==3.4.7",
     "sphinx-toolbox>=2.5.0",
 ]


### PR DESCRIPTION
This fixes minimum-deps tests, as seen broken in #275 

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

-----
