### PR TITLE
feat: don't use error list as details

### DIFF
--- a/craft_store/publisher/_publishergw.py
+++ b/craft_store/publisher/_publishergw.py
@@ -91,9 +91,13 @@ class PublisherGateway:
         else:
             fancy_error_list = errors.StoreErrorList(error_list)
             brief = f"{brief}.\n{fancy_error_list}"
-        raise errors.CraftStoreError(
-            brief, store_errors=errors.StoreErrorList(error_list)
-        )
+
+        if error_list:
+            # Log the errors, but don't pass them to CraftStoreError or they will be
+            # duplicated.
+            logger.debug(f"Errors from the store:\n{errors.StoreErrorList(error_list)}")
+
+        raise errors.CraftStoreError(brief)
 
     @staticmethod
     def _check_keys(


### PR DESCRIPTION
A recent-ish change in craft-cli made an error's 'details' get shown to the user by default. This means that CraftStoreErrors with a single store error would get the actual error message printed twice - once from the 'brief' and once from the 'details'. Instead, log the error list (as it has relevant error codes).

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

-----
