### PR TITLE
ci: switch to public runners

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,4 +15,5 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["jammy", "noble", "windows-latest", "macos-latest"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest", "macos-latest"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04-arm"]'


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

-----

Required test changes are at https://github.com/canonical/canonical-repo-automation/pull/286