### PR TITLE
chore: update ruff pre-commit away from legacy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: "v0.15.16"
     hooks:
       # Run the linter
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       # Run the formatter
       - id: ruff-format


### PR DESCRIPTION
We were still using the legacy `ruff` pre-commit hook rather than the new `ruff-check` one. This fixes that.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
