### PR TITLE
ci: add ubuntu-26.04 to test matrices

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -36,8 +36,8 @@ jobs:
     needs: filter
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest", "macos-latest"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "ubuntu-26.04", "ubuntu-26.04-arm", "windows-latest", "macos-latest"]'
       fast-test-python-versions: '["3.10", "3.11", "3.12", "3.14"]'
-      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04-arm", "ubuntu-26.04", "ubuntu-26.04-arm"]'
       slow-test-python-versions: '["3.10", "3.11", "3.12", "3.14"]'
       source-files: ${{ needs.filter.outputs.source-files }}


### PR DESCRIPTION
Adds ubuntu-26.04 and ubuntu-26.04-arm to fast and slow test platforms in qa.yaml.