### PR TITLE
fix(auth): error more nicely on keyring errors

### DIFF
--- a/craft_store/auth.py
+++ b/craft_store/auth.py
@@ -237,7 +237,7 @@ class Auth:
         """
         try:
             password = self._keyring.get_password(self.application_name, self.host)
-        except keyring.errors.KeyringLocked as exc:
+        except (keyring.errors.KeyringLocked, *KEYRING_EXCEPTIONS) as exc:
             raise errors.KeyringUnlockError from exc
 
         if password is not None:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,18 @@
 Changelog
 *********
 
+.. _release-3.3.1:
+
+3.3.1 (unreleased)
+------------------
+
+Bug fixes:
+
+- Translate keyring initialization failures into ``KeyringUnlockError`` when the
+  keyring cannot be unlocked.
+
+For a complete list of commits, check out the `3.3.1`_ release on GitHub.
+
 .. _release-3.3.0:
 
 3.3.0 (2025-07-02)
@@ -233,3 +245,4 @@ Bug fixes:
 .. _3.2.1: https://github.com/canonical/craft-store/releases/tag/3.2.1
 .. _3.2.2: https://github.com/canonical/craft-store/releases/tag/3.2.2
 .. _3.3.0: https://github.com/canonical/craft-store/releases/tag/3.3.0
+.. _3.3.1: https://github.com/canonical/craft-store/releases/tag/3.3.1

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -62,3 +62,50 @@ def test_auth_from_environment(monkeypatch):
     auth = Auth("fakecraft", "fakestore.com", environment_auth="CREDENTIALS")
 
     assert auth.get_credentials() == "secret-keys"
+
+
+class _BrokenInitKeyring(keyring.backend.KeyringBackend):
+    """Keyring that raises InitError on all operations.
+
+    Simulates a SecretService keyring on a headless machine where the
+    collection cannot be created or accessed (e.g. "Prompt dismissed.").
+    """
+
+    priority = 1
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        raise keyring.errors.InitError(
+            "Failed to create the collection: Prompt dismissed."
+        )
+
+    def get_password(self, service: str, username: str) -> str | None:
+        raise keyring.errors.InitError(
+            "Failed to create the collection: Prompt dismissed."
+        )
+
+    def delete_password(self, service: str, username: str) -> None:
+        raise keyring.errors.InitError(
+            "Failed to create the collection: Prompt dismissed."
+        )
+
+
+@pytest.fixture
+def _broken_init_keyring():
+    current_keyring = keyring.get_keyring()
+    keyring.set_keyring(_BrokenInitKeyring())
+    yield
+    keyring.set_keyring(current_keyring)
+
+
+@pytest.mark.usefixtures("_broken_init_keyring")
+def test_auth_ensure_no_credentials_headless_keyring():
+    """Regression test for https://github.com/canonical/craft-store/issues/58.
+
+    On a headless machine, keyring operations raise InitError because the
+    SecretService collection cannot be unlocked interactively. This must
+    surface as a KeyringUnlockError rather than an unhandled internal error.
+    """
+    auth = Auth("fakecraft", "fakestore.com")
+
+    with pytest.raises(errors.KeyringUnlockError):
+        auth.ensure_no_credentials()

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -20,6 +20,7 @@ import keyring.errors
 import pytest
 from craft_store import errors
 from craft_store.auth import Auth, MemoryKeyring
+from jaraco.classes import properties
 
 pytestmark = pytest.mark.timeout(10)  # Timeout if any test takes over 10 sec.
 
@@ -71,7 +72,9 @@ class _BrokenInitKeyring(keyring.backend.KeyringBackend):
     collection cannot be created or accessed (e.g. "Prompt dismissed.").
     """
 
-    priority = 1
+    @properties.classproperty  # type: ignore[misc]
+    def priority(self) -> int | float:
+        return 1
 
     def set_password(self, service: str, username: str, password: str) -> None:
         raise keyring.errors.InitError(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -313,11 +313,11 @@ def test_file_keyring_storage_path(tmp_path):
     assert k.credentials_file == tmp_path / "credentials.json"
 
 
-test_exceptions: list[type[Exception]] = [keyring.errors.InitError]
+test_exceptions: list[Exception] = [keyring.errors.InitError()]
 if sys.platform == "linux":
     from secretstorage.exceptions import SecretServiceNotAvailableException
 
-    test_exceptions.append(SecretServiceNotAvailableException)
+    test_exceptions.append(SecretServiceNotAvailableException())
 
 
 @pytest.mark.parametrize("exception", test_exceptions)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -320,6 +320,22 @@ if sys.platform == "linux":
     test_exceptions.append(SecretServiceNotAvailableException)
 
 
+@pytest.mark.parametrize("exception", test_exceptions)
+def test_ensure_no_credentials_init_error(fake_keyring, mocker, exception):
+    """Regression test for https://github.com/canonical/craft-store/issues/58.
+
+    When the keyring raises InitError (e.g. on a headless machine where the
+    SecretService collection cannot be created), ensure_no_credentials() must
+    convert it to a KeyringUnlockError instead of propagating the raw exception.
+    """
+    mocker.patch.object(fake_keyring, "get_password", side_effect=exception)
+
+    auth = Auth("fakeclient", "fakestore.com")
+
+    with pytest.raises(errors.KeyringUnlockError):
+        auth.ensure_no_credentials()
+
+
 @pytest.mark.disable_fake_keyring
 @pytest.mark.parametrize("exception", test_exceptions)
 def test_secretservice_file_fallsback(mocker, exception):


### PR DESCRIPTION
This catches more keyring errors while unlocking and raises them with the KeyringUnlockError.

CRAFT-5224
Fixes #58 

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
