### PR TITLE
fix(test): make endpoint tests less flaky

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -99,6 +99,7 @@ def expires():
         )
 
     with patch("craft_store.endpoints.datetime", wraps=datetime.datetime) as dt_mock:
+        dt_mock.now.return_value = now
         dt_mock.utcnow.return_value = now
         yield offset_iso_dt
 

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -138,13 +138,14 @@ def test_snap_store_channels():
         ttl=1000,
         channels=["stable", "track/edge"],
     )
-    after = datetime.datetime.now(tz=datetime.timezone.utc)
+    after = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
 
     assert result["permissions"] == ["permission-foo", "permission-bar"]
     assert result["description"] == "client description"
     assert result["channels"] == ["stable", "track/edge"]
 
     actual_dt = datetime.datetime.fromisoformat(result["expires"])
+    assert actual_dt.tzinfo is not None
     assert before + datetime.timedelta(seconds=1000) <= actual_dt
     assert actual_dt <= after + datetime.timedelta(seconds=1000)
 

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -140,11 +140,12 @@ def test_snap_store_channels():
     )
     after_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
 
-    assert result["permissions"] == ["permission-foo", "permission-bar"]
-    assert result["description"] == "client description"
-    assert result["channels"] == ["stable", "track/edge"]
-
-    actual_expiry = datetime.datetime.fromisoformat(result["expires"])
+    actual_expiry = datetime.datetime.fromisoformat(result.pop("expires"))
+    assert result == {
+        "permissions": ["permission-foo", "permission-bar"],
+        "description": "client description",
+        "channels": ["stable", "track/edge"],
+    }
     assert actual_expiry.tzinfo is not None
     assert before_request + datetime.timedelta(seconds=1000) <= actual_expiry
     assert actual_expiry <= after_request + datetime.timedelta(seconds=1000)

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -13,8 +13,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import datetime
-
 import pytest
 from craft_store import endpoints
 
@@ -128,31 +126,20 @@ def test_snap_store(expires):
     }
 
 
-def test_snap_store_channels():
+def test_snap_store_channels(expires):
     snap_store = endpoints.SNAP_STORE
 
-    before_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(
-        microsecond=0
-    )
-    result = snap_store.get_token_request(
+    assert snap_store.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",
         ttl=1000,
         channels=["stable", "track/edge"],
-    )
-    after_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(
-        microsecond=0
-    )
-
-    actual_expiry = datetime.datetime.fromisoformat(result.pop("expires"))
-    assert result == {
+    ) == {
         "permissions": ["permission-foo", "permission-bar"],
         "description": "client description",
+        "expires": expires(1000),
         "channels": ["stable", "track/edge"],
     }
-    assert actual_expiry.tzinfo is not None
-    assert before_request + datetime.timedelta(seconds=1000) <= actual_expiry
-    assert actual_expiry <= after_request + datetime.timedelta(seconds=1000)
 
 
 def test_snap_store_packages(expires):

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -131,14 +131,18 @@ def test_snap_store(expires):
 def test_snap_store_channels():
     snap_store = endpoints.SNAP_STORE
 
-    before_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
+    before_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(
+        microsecond=0
+    )
     result = snap_store.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",
         ttl=1000,
         channels=["stable", "track/edge"],
     )
-    after_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
+    after_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(
+        microsecond=0
+    )
 
     actual_expiry = datetime.datetime.fromisoformat(result.pop("expires"))
     assert result == {

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import datetime
 
 import pytest
 from craft_store import endpoints
@@ -130,17 +131,34 @@ def test_snap_store(expires):
 def test_snap_store_channels(expires):
     snap_store = endpoints.SNAP_STORE
 
-    assert snap_store.get_token_request(
+    result = snap_store.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",
         ttl=1000,
         channels=["stable", "track/edge"],
-    ) == {
+    )
+
+    # Validate all fields except the timestamp which can vary slightly
+    expected = {
         "permissions": ["permission-foo", "permission-bar"],
         "description": "client description",
-        "expires": expires(1000),
         "channels": ["stable", "track/edge"],
     }
+
+    # Check the non-timestamp fields first
+    for key, value in expected.items():
+        assert result[key] == value
+
+    # Validate the timestamp is correct (approximately)
+    expected_expires = expires(1000)
+    actual_expires = result["expires"]
+
+    # Parse and compare timestamps
+    expected_dt = datetime.datetime.fromisoformat(
+        expected_expires.replace("Z", "+00:00")
+    )
+    actual_dt = datetime.datetime.fromisoformat(actual_expires.replace("Z", "+00:00"))
+    assert abs((actual_dt - expected_dt).total_seconds()) < 2
 
 
 def test_snap_store_packages(expires):

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -131,23 +131,23 @@ def test_snap_store(expires):
 def test_snap_store_channels():
     snap_store = endpoints.SNAP_STORE
 
-    before = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
+    before_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
     result = snap_store.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",
         ttl=1000,
         channels=["stable", "track/edge"],
     )
-    after = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
+    after_request = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
 
     assert result["permissions"] == ["permission-foo", "permission-bar"]
     assert result["description"] == "client description"
     assert result["channels"] == ["stable", "track/edge"]
 
-    actual_dt = datetime.datetime.fromisoformat(result["expires"])
-    assert actual_dt.tzinfo is not None
-    assert before + datetime.timedelta(seconds=1000) <= actual_dt
-    assert actual_dt <= after + datetime.timedelta(seconds=1000)
+    actual_expiry = datetime.datetime.fromisoformat(result["expires"])
+    assert actual_expiry.tzinfo is not None
+    assert before_request + datetime.timedelta(seconds=1000) <= actual_expiry
+    assert actual_expiry <= after_request + datetime.timedelta(seconds=1000)
 
 
 def test_snap_store_packages(expires):

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -128,37 +128,25 @@ def test_snap_store(expires):
     }
 
 
-def test_snap_store_channels(expires):
+def test_snap_store_channels():
     snap_store = endpoints.SNAP_STORE
 
+    before = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
     result = snap_store.get_token_request(
         permissions=["permission-foo", "permission-bar"],
         description="client description",
         ttl=1000,
         channels=["stable", "track/edge"],
     )
+    after = datetime.datetime.now(tz=datetime.timezone.utc)
 
-    # Validate all fields except the timestamp which can vary slightly
-    expected = {
-        "permissions": ["permission-foo", "permission-bar"],
-        "description": "client description",
-        "channels": ["stable", "track/edge"],
-    }
+    assert result["permissions"] == ["permission-foo", "permission-bar"]
+    assert result["description"] == "client description"
+    assert result["channels"] == ["stable", "track/edge"]
 
-    # Check the non-timestamp fields first
-    for key, value in expected.items():
-        assert result[key] == value
-
-    # Validate the timestamp is correct (approximately)
-    expected_expires = expires(1000)
-    actual_expires = result["expires"]
-
-    # Parse and compare timestamps
-    expected_dt = datetime.datetime.fromisoformat(
-        expected_expires.replace("Z", "+00:00")
-    )
-    actual_dt = datetime.datetime.fromisoformat(actual_expires.replace("Z", "+00:00"))
-    assert abs((actual_dt - expected_dt).total_seconds()) < 2
+    actual_dt = datetime.datetime.fromisoformat(result["expires"])
+    assert before + datetime.timedelta(seconds=1000) <= actual_dt
+    assert actual_dt <= after + datetime.timedelta(seconds=1000)
 
 
 def test_snap_store_packages(expires):


### PR DESCRIPTION
We often get fast test failures because these tests are somewhat flaky in CI (probably due to the machines being slow). This should make them far less flaky.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
