### PR TITLE
ci: pass staging username via vars in QA workflow

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -41,9 +41,8 @@ jobs:
       slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04-arm", "ubuntu-26.04", "ubuntu-26.04-arm"]'
       slow-test-python-versions: '["3.10", "3.11", "3.12", "3.14"]'
       extra-env-vars: |
-        STAGING_SSO_USERNAME=$SECRET_1
-        STAGING_SSO_PASSWORD=$SECRET_2
+        STAGING_SSO_USERNAME=${{ vars.STAGING_SSO_USERNAME }}
+        STAGING_SSO_PASSWORD=$SECRET_1
       source-files: ${{ needs.filter.outputs.source-files }}
     secrets:
-      secret-1: ${{ vars.STAGING_SSO_USERNAME }}
-      secret-2: ${{ secrets.STAGING_SSO_PASSWORD }}
+      secret-1: ${{ secrets.STAGING_SSO_PASSWORD }}


### PR DESCRIPTION
## Summary
- apply the review suggestion from https://github.com/canonical/starflow/pull/156#discussion_r3461264550
- pass STAGING_SSO_USERNAME directly from workflow vars in extra-env-vars
- keep only STAGING_SSO_PASSWORD in reusable-workflow secrets (secret-1)

## Validation
- make lint-actions
- simulated reusable-workflow env expansion logic with one secret slot and direct username var