### PR TITLE
ci: pass staging username via vars in qa workflow

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -41,9 +41,8 @@ jobs:
       slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04-arm", "ubuntu-26.04", "ubuntu-26.04-arm"]'
       slow-test-python-versions: '["3.10", "3.11", "3.12", "3.14"]'
       extra-env-vars: |
-        STAGING_SSO_USERNAME=$SECRET_1
-        STAGING_SSO_PASSWORD=$SECRET_2
+        STAGING_SSO_USERNAME=${{ vars.STAGING_SSO_USERNAME }}
+        STAGING_SSO_PASSWORD=$SECRET_1
       source-files: ${{ needs.filter.outputs.source-files }}
     secrets:
-      secret-1: ${{ vars.STAGING_SSO_USERNAME }}
-      secret-2: ${{ secrets.STAGING_SSO_PASSWORD }}
+      secret-1: ${{ secrets.STAGING_SSO_PASSWORD }}


### PR DESCRIPTION
Apply the review suggestion from [starflow/156](https://github.com/canonical/starflow/pull/156) by passing the username via workflow vars and using reusable-workflow secret slots only for the password.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
