### PR TITLE
docs: fix link to craft cli

### DIFF
--- a/docs/how-to/craft-cli-upload-progress.rst
+++ b/docs/how-to/craft-cli-upload-progress.rst
@@ -13,5 +13,5 @@ The example requires setting the environment variable
 .. literalinclude:: code/craft-cli-upload-progress/craft_cli_upload.py
     :language: python
 
-.. _craft-cli: https://canonical-craft-cli.readthedocs-hosted.com/en/latest/
+.. _craft-cli: https://canonical-craft-cli.readthedocs-hosted.com/latest/
 .. _snapcraft export-login: https://documentation.ubuntu.com/snapcraft/stable/how-to/publishing/authenticate/


### PR DESCRIPTION
The path changed.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
