### PR TITLE
feat: add constants for more known attenuations

### DIFF
--- a/craft_store/attenuations.py
+++ b/craft_store/attenuations.py
@@ -17,6 +17,12 @@
 """Attenuations for Snap Store and Charmhub discharged Macaroons."""
 
 # read/write access.
+ACCOUNT_MANAGE_KEYS = "account-manage-keys"
+"""Manage account keys."""
+
+ACCOUNT_MANAGE_METADATA = "account-manage-metadata"
+"""Manage account metadata."""
+
 ACCOUNT_REGISTER_PACKAGE = "account-register-package"
 """Register or request a new package name under a given account."""
 
@@ -45,6 +51,9 @@ PACKAGE_MANAGE_REVISIONS = "package-manage-revisions"
 Upload new blobs, check for upload status, reject a revision blocked on
 manual review or request manual review.
 """
+
+STORE_MANAGE = "store-manage"
+"""Manage store settings."""
 
 # read only access.
 ACCOUNT_VIEW_PACKAGES = "account-view-packages"
@@ -76,3 +85,6 @@ history of a package.
 
 PACKAGE_VIEW_REVISIONS = "package-view-revisions"
 """List the existing revisions for a package, along with status information."""
+
+STORE_VIEW = "store-view"
+"""View store settings."""

--- a/craft_store/login/_ubuntuone.py
+++ b/craft_store/login/_ubuntuone.py
@@ -22,7 +22,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 import pymacaroons  # type: ignore[import-untyped]
 
-from craft_store import auth, creds, errors
+from craft_store import attenuations, auth, creds, errors
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class UbuntuOneLogin:
             email="user@example.com",
             password="password123",
             base_url="https://api.charmhub.io",
-            permissions=["package-view"],
+            permissions=[PACKAGE_VIEW],
         )
 
     :param base_url: The base URL for the store API. Commonly set to Charmhub
@@ -150,7 +150,7 @@ class UbuntuOneLogin:
     ) -> tuple[pymacaroons.Macaroon, pymacaroons.Macaroon]:
         """Login with Ubuntu One credentials and return root and discharged macaroons."""
         if permissions is None:
-            permissions = ["account-view-packages"]
+            permissions = [attenuations.ACCOUNT_VIEW_PACKAGES]
 
         root = self._get_macaroon(
             permissions=permissions,

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,4 +1,5 @@
 # Leave a blank line at the end of this file to support concatenation
+attenuations?
 backend
 backends
 Canonical('s)?

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+.. _release-3.4.0:
+
+3.4.0 (unreleased)
+------------------
+
+- Add constants for more known attenuations.
+
+For a complete list of commits, check out the `3.4.0`_ release on GitHub.
+
 .. _release-3.3.1:
 
 3.3.1 (unreleased)
@@ -246,3 +255,4 @@ Bug fixes:
 .. _3.2.2: https://github.com/canonical/craft-store/releases/tag/3.2.2
 .. _3.3.0: https://github.com/canonical/craft-store/releases/tag/3.3.0
 .. _3.3.1: https://github.com/canonical/craft-store/releases/tag/3.3.1
+.. _3.4.0: https://github.com/canonical/craft-store/releases/tag/3.4.0

--- a/scripts/usso_login_demo.py
+++ b/scripts/usso_login_demo.py
@@ -8,7 +8,7 @@ import os
 import sys
 from urllib.parse import urlparse
 
-from craft_store import Auth, errors, publisher
+from craft_store import Auth, attenuations, errors, publisher
 from craft_store.login import UbuntuOneLogin
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,10 @@ def main() -> None:
             login_url=login_url,
             application_name=application_name,
             otp=otp,
-            permissions=["account-view-packages", "account-register-package"],
+            permissions=[
+                attenuations.ACCOUNT_VIEW_PACKAGES,
+                attenuations.ACCOUNT_REGISTER_PACKAGE,
+            ],
         )
     except errors.UbuntuOneCredentialsError as e:
         print(f"Login failed: {e}", file=sys.stderr)

--- a/tests/unit/test_ubuntuone_login.py
+++ b/tests/unit/test_ubuntuone_login.py
@@ -16,7 +16,7 @@
 
 import pytest
 import pytest_httpx
-from craft_store import errors
+from craft_store import attenuations, errors
 from craft_store.login import UbuntuOneLogin
 from pymacaroons import Macaroon
 
@@ -62,7 +62,7 @@ def test_login_with_raises_when_otp_missing(
             base_url="https://api.example.test",
             login_url="https://login.ubuntu.com",
             store_auth=mock_auth,
-            permissions=["account-view-packages"],
+            permissions=[attenuations.ACCOUNT_VIEW_PACKAGES],
         )
 
 
@@ -98,7 +98,7 @@ def test_login_with_raises_on_bad_credentials(
             login_url="https://login.ubuntu.com",
             store_auth=mock_auth,
             otp=otp,
-            permissions=["account-view-packages"],
+            permissions=[attenuations.ACCOUNT_VIEW_PACKAGES],
         )
 
     assert exc_info.value.error_code == "INVALID_DATA"
@@ -132,7 +132,7 @@ def test_login_with_saves_credentials(
         login_url="https://login.ubuntu.com",
         store_auth=mock_auth,
         otp="123456",
-        permissions=["account-view-packages"],
+        permissions=[attenuations.ACCOUNT_VIEW_PACKAGES],
     )
 
     mock_auth.set_credentials.assert_called_once()
@@ -170,7 +170,7 @@ def test_login_with_rejects_invalid_ttl(
             base_url="https://api.example.test",
             login_url="https://login.ubuntu.com",
             store_auth=mock_auth,
-            permissions=["account-view-packages"],
+            permissions=[attenuations.ACCOUNT_VIEW_PACKAGES],
             ttl=ttl,
         )
 


### PR DESCRIPTION
Also uses those constants instead of magic strings.

Fixes #386
CRAFT-5221

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
