### PR TITLE
fix: update packages typing

### DIFF
--- a/craft_store/login/_ubuntuone.py
+++ b/craft_store/login/_ubuntuone.py
@@ -15,7 +15,7 @@
 """Ubuntu One Login Client."""
 
 import logging
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from http import HTTPStatus
 from urllib.parse import urljoin, urlparse
 
@@ -86,7 +86,7 @@ class UbuntuOneLogin:
         otp: str | None = None,
         permissions: Collection[str] | None = None,
         channels: Collection[str] | None = None,
-        packages: Collection[str] | None = None,
+        packages: Collection[Mapping[str, str]] | None = None,
         ttl: int = _SECONDS_PER_DAY,
     ) -> tuple[pymacaroons.Macaroon, pymacaroons.Macaroon]:
         """Login with Ubuntu One credentials and return root and discharged macaroons.
@@ -107,7 +107,9 @@ class UbuntuOneLogin:
             defaults to ``["account-view-packages"]``. See store API documentation for
             valid permission values.
         :param channels: Optional list of channel names to restrict access to.
-        :param packages: Optional list of package specs to restrict access to.
+        :param packages: Optional list of package specs to restrict access to. Each
+            package is a mapping with a "type" key (e.g. "charm", "bundle", "snap")
+            and a "name" key.
         :param ttl: Time-to-live in seconds for the macaroon. Defaults to 24 hours.
 
         :return: A tuple of (root_macaroon, discharged_macaroon) ready for use with the
@@ -145,7 +147,7 @@ class UbuntuOneLogin:
         otp: str | None = None,
         permissions: Collection[str] | None = None,
         channels: Collection[str] | None = None,
-        packages: Collection[str] | None = None,
+        packages: Collection[Mapping[str, str]] | None = None,
         ttl: int = _SECONDS_PER_DAY,
     ) -> tuple[pymacaroons.Macaroon, pymacaroons.Macaroon]:
         """Login with Ubuntu One credentials and return root and discharged macaroons."""
@@ -190,7 +192,7 @@ class UbuntuOneLogin:
         *,
         permissions: Collection[str],
         channels: Collection[str] | None = None,
-        packages: Collection[str] | None = None,
+        packages: Collection[Mapping[str, str]] | None = None,
         ttl: int = _SECONDS_PER_DAY,
     ) -> pymacaroons.Macaroon:
         """Request an unsigned macaroon from the store API.
@@ -198,7 +200,9 @@ class UbuntuOneLogin:
         :param permissions: List of permission strings (e.g., ``["package-view"]``,
             ``["package-manage"]``). Required.
         :param channels: Optional list of channel names to restrict access to.
-        :param packages: Optional list of package specs to restrict access to.
+        :param packages: Optional list of package specs to restrict access to. Each
+            package is a mapping with a "type" key (e.g. "charm", "bundle", "snap")
+            and a "name" key.
         :param ttl: Time-to-live in seconds. Defaults to 86400 (24 hours).
 
         :return: An unsigned macaroon that must be discharged with

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,24 +4,20 @@ Changelog
 
 .. _release-3.4.0:
 
-3.4.0 (unreleased)
+3.4.0 (2026-07-16)
 ------------------
 
+New features:
+
+- Add PublisherGateway login with Ubuntu One SSO
 - Add constants for more known attenuations.
-
-For a complete list of commits, check out the `3.4.0`_ release on GitHub.
-
-.. _release-3.3.1:
-
-3.3.1 (unreleased)
-------------------
 
 Bug fixes:
 
 - Translate keyring initialization failures into ``KeyringUnlockError`` when the
   keyring cannot be unlocked.
 
-For a complete list of commits, check out the `3.3.1`_ release on GitHub.
+For a complete list of commits, check out the `3.4.0`_ release on GitHub.
 
 .. _release-3.3.0:
 
@@ -254,5 +250,4 @@ Bug fixes:
 .. _3.2.1: https://github.com/canonical/craft-store/releases/tag/3.2.1
 .. _3.2.2: https://github.com/canonical/craft-store/releases/tag/3.2.2
 .. _3.3.0: https://github.com/canonical/craft-store/releases/tag/3.3.0
-.. _3.3.1: https://github.com/canonical/craft-store/releases/tag/3.3.1
 .. _3.4.0: https://github.com/canonical/craft-store/releases/tag/3.4.0


### PR DESCRIPTION
Updates the packages type to be a mapping.

If you pass it strings, it errors with:
```
charmcraft login --export creds.txt --charm home-assistant
Email address: callahan.kovacs@canonical.com
Password:
'home-assistant' is not of type 'object' at /packages/0
Detailed information: api-error
Full execution log: '/home/callahan.kovacs@canonical.com/.local/state/charmcraft/log/charmcraft-20260715-143035.881847.log'
```

Also prepares for the first release of craft-store in over a year!

(CHARMCRAFT-667)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
