### PR TITLE
docs: add craft-cli intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -285,6 +285,7 @@ rst_prolog = """
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "craft-cli": ("https://documentation.ubuntu.com/craft-cli/latest", None),
     "starflow": ("https://documentation.ubuntu.com/starflow/latest", None),
 }
 

--- a/docs/how-to/craft-cli-upload-progress.rst
+++ b/docs/how-to/craft-cli-upload-progress.rst
@@ -3,7 +3,8 @@
 Using craft-cli for upload progress
 ===================================
 
-Progress can be provided by use of craft-cli_. This example will upload
+Progress can be provided by use of
+:external+craft-cli:doc:`craft-cli <index>`. This example will upload
 ``./test.snap`` with something that looks like the following:
 
 The example requires setting the environment variable
@@ -13,5 +14,4 @@ The example requires setting the environment variable
 .. literalinclude:: code/craft-cli-upload-progress/craft_cli_upload.py
     :language: python
 
-.. _craft-cli: https://canonical-craft-cli.readthedocs-hosted.com/latest/
 .. _snapcraft export-login: https://documentation.ubuntu.com/snapcraft/stable/how-to/publishing/authenticate/


### PR DESCRIPTION
Adds `craft-cli` to the Sphinx `intersphinx_mapping` and replaces the hardcoded link to Craft CLI's documentation in `docs/how-to/craft-cli-upload-progress.rst` with an `:external+craft-cli:` reference, following the same approach used in [canonical/craft-application#1136](https://github.com/canonical/craft-application/pull/1136).