### PR TITLE
style: fix ruff 0.16 warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,6 +357,7 @@ ignore = [
     "S103",    # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
     "S108",    # Allow Probable insecure usage of temporary file or directory
     "PLR0913", # Allow many arguments for test functions (useful if we need many fixtures)
+    "PLR0917", # Allow many positional arguments for test functions (useful if we need many fixtures)
     "PLR2004", # Allow magic values in tests
     "SLF",     # Allow accessing private members from tests.
     "FBT001",  # Boolean-typed positional arguments are common in tests (e.g. parametrize)


### PR DESCRIPTION
Ignores a new directive, copied from Starbase.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/craft-store/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
